### PR TITLE
Decouple message types and encoding versions

### DIFF
--- a/packages/oracle/migrations/20220411_initial_schema.sql
+++ b/packages/oracle/migrations/20220411_initial_schema.sql
@@ -28,12 +28,12 @@ CREATE TABLE encoding_versions (
 
 CREATE TABLE message_types (
     id integer PRIMARY KEY,
-    name varchar(63) NOT NULL UNIQUE,
-    introduced_with integer NOT NULL REFERENCES encoding_versions (id) ON DELETE CASCADE
+    name varchar(63) NOT NULL UNIQUE
 );
 
 CREATE TABLE messages (
     id integer PRIMARY KEY,
     tx_id integer NOT NULL REFERENCES data_edge_calls (id) ON DELETE CASCADE,
-    message_type_id integer NOT NULL REFERENCES message_types (id) ON DELETE CASCADE
+    message_type_id integer NOT NULL REFERENCES message_types (id) ON DELETE CASCADE,
+    envoding_version_id integer NOT NULL REFERENCES encoding_versions (id) ON DELETE CASCADE
 );

--- a/packages/oracle/migrations/20220411_initial_schema.sql
+++ b/packages/oracle/migrations/20220411_initial_schema.sql
@@ -35,5 +35,5 @@ CREATE TABLE messages (
     id integer PRIMARY KEY,
     tx_id integer NOT NULL REFERENCES data_edge_calls (id) ON DELETE CASCADE,
     message_type_id integer NOT NULL REFERENCES message_types (id) ON DELETE CASCADE,
-    envoding_version_id integer NOT NULL REFERENCES encoding_versions (id) ON DELETE CASCADE
+    encoding_version_id integer NOT NULL REFERENCES encoding_versions (id) ON DELETE CASCADE
 );

--- a/packages/oracle/migrations/20220503121545_message_types.sql
+++ b/packages/oracle/migrations/20220503121545_message_types.sql
@@ -1,0 +1,10 @@
+INSERT INTO message_types (
+    name)
+VALUES (
+    'SetBlockNumbersForNextEpoch'),
+(
+    'RegisterNetworks'),
+(
+    'CorrectEpochs'),
+(
+    'UpdateVersion')


### PR DESCRIPTION
This is probably insignificant, so feel free to close this PR without merging.

This PR transfers the relationship of `encoding_versions` and `message_types` from the latter to the `messages` table.

Currently, a `message_types` record is associated with a `encoding_versions` record.
After this PR, this relationship will be described by each row in the `messages` table.

The only benefit of this change is that it will prevent the `message_types` table from growing as `encoding_versions` grows. 