### PR TITLE
Retries with exponential backoffs for JRPS calls

### DIFF
--- a/packages/oracle/Cargo.toml
+++ b/packages/oracle/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 actix-web = "4"
 async-trait = "0.1.52"
+backoff = { version = "0.4.0", features = [ "tokio" ] }
 clap = { version = "3.0.0", features = ["derive"] }
 ctrlc = "3.2.1"
 envconfig = "0.10.0"

--- a/packages/oracle/Cargo.toml
+++ b/packages/oracle/Cargo.toml
@@ -12,6 +12,7 @@ ctrlc = "3.2.1"
 envconfig = "0.10.0"
 epoch-encoding = { path = "../encoding" }
 futures = "0.3.21"
+jsonrpc-core = "18.0.0"
 lazy_static = "1"
 prometheus = "0.13.0"
 secp256k1 = "0.21"

--- a/packages/oracle/src/emitter.rs
+++ b/packages/oracle/src/emitter.rs
@@ -45,7 +45,7 @@ impl<'a> Emitter<'a> {
         };
         let signed = self
             .client
-            .sign_transaction(tx_object, self.owner_private_key)
+            .sign_transaction(tx_object, &self.owner_private_key)
             .await?;
         debug!(hash = ?signed.transaction_hash, nonce = nonce, "signed transaction");
         let receipt = self.client.send_transaction(signed).await?;

--- a/packages/oracle/src/indexed_chain.rs
+++ b/packages/oracle/src/indexed_chain.rs
@@ -1,23 +1,21 @@
 use std::time::Duration;
 
 use crate::store::Caip2ChainId;
-use crate::transport::Transport;
+use crate::transport::JsonRpcExponentialBackoff;
 use url::Url;
 use web3::types::U64;
+use web3::Web3;
 
 #[derive(Debug, Clone)]
 pub struct IndexedChain {
     chain_id: Caip2ChainId,
-    transport: Transport,
+    web3: Web3<JsonRpcExponentialBackoff>,
 }
 
 impl IndexedChain {
     pub fn new(chain_id: Caip2ChainId, jrpc_url: Url, retry_wait_time: Duration) -> Self {
-        let transport = Transport::new(jrpc_url, retry_wait_time);
-        Self {
-            chain_id,
-            transport,
-        }
+        let web3 = Web3::new(JsonRpcExponentialBackoff::new(jrpc_url, retry_wait_time));
+        Self { chain_id, web3 }
     }
 
     pub fn id(&self) -> &Caip2ChainId {
@@ -25,6 +23,6 @@ impl IndexedChain {
     }
 
     pub async fn get_latest_block(&self) -> Result<U64, web3::Error> {
-        self.transport.get_latest_block().await
+        self.web3.eth().block_number().await
     }
 }

--- a/packages/oracle/src/indexed_chain.rs
+++ b/packages/oracle/src/indexed_chain.rs
@@ -1,20 +1,23 @@
-use url::Url;
-use web3::{transports::Http, types::U64, Web3};
+use std::time::Duration;
 
 use crate::store::Caip2ChainId;
+use crate::transport::Transport;
+use url::Url;
+use web3::types::U64;
 
 #[derive(Debug, Clone)]
 pub struct IndexedChain {
     chain_id: Caip2ChainId,
-    client: Web3<Http>,
+    transport: Transport,
 }
 
 impl IndexedChain {
-    pub fn new(chain_id: Caip2ChainId, jrpc_url: Url) -> Self {
-        // Unwrap: URLs were already parsed and are valid.
-        let transport = Http::new(jrpc_url.as_str()).expect("failed to create HTTP transport");
-        let client = Web3::new(transport);
-        Self { chain_id, client }
+    pub fn new(chain_id: Caip2ChainId, jrpc_url: Url, retry_wait_time: Duration) -> Self {
+        let transport = Transport::new(jrpc_url, retry_wait_time);
+        Self {
+            chain_id,
+            transport,
+        }
     }
 
     pub fn id(&self) -> &Caip2ChainId {
@@ -22,6 +25,6 @@ impl IndexedChain {
     }
 
     pub async fn get_latest_block(&self) -> Result<U64, web3::Error> {
-        self.client.eth().block_number().await
+        self.transport.get_latest_block().await
     }
 }

--- a/packages/oracle/src/indexed_chain.rs
+++ b/packages/oracle/src/indexed_chain.rs
@@ -1,7 +1,6 @@
-use std::time::Duration;
-
 use crate::store::Caip2ChainId;
 use crate::transport::JsonRpcExponentialBackoff;
+use std::time::Duration;
 use url::Url;
 use web3::types::U64;
 use web3::Web3;

--- a/packages/oracle/src/main.rs
+++ b/packages/oracle/src/main.rs
@@ -10,6 +10,7 @@ mod metrics;
 mod networks_diff;
 mod protocol_chain;
 mod store;
+mod transport;
 
 use crate::ctrlc::CtrlcHandler;
 use diagnostics::init_logging;

--- a/packages/oracle/src/protocol_chain.rs
+++ b/packages/oracle/src/protocol_chain.rs
@@ -1,21 +1,21 @@
-use crate::{store::Caip2ChainId, transport::Transport};
+use crate::{store::Caip2ChainId, transport::JsonRpcExponentialBackoff};
 use secp256k1::SecretKey;
 use std::time::Duration;
 use url::Url;
-use web3::types::{SignedTransaction, TransactionParameters, TransactionReceipt, U64};
+use web3::{
+    types::{SignedTransaction, TransactionParameters, TransactionReceipt, U64},
+    Web3,
+};
 
 #[derive(Debug, Clone)]
 pub struct ProtocolChain {
     chain_id: Caip2ChainId,
-    transport: Transport,
+    web3: Web3<JsonRpcExponentialBackoff>,
 }
 impl ProtocolChain {
-    pub fn new(chain_id: Caip2ChainId, jrpc_provider: Url, retry_wait_time: Duration) -> Self {
-        let transport = Transport::new(jrpc_provider, retry_wait_time);
-        Self {
-            chain_id,
-            transport,
-        }
+    pub fn new(chain_id: Caip2ChainId, jrpc_url: Url, retry_wait_time: Duration) -> Self {
+        let web3 = Web3::new(JsonRpcExponentialBackoff::new(jrpc_url, retry_wait_time));
+        Self { chain_id, web3 }
     }
 
     pub async fn sign_transaction(
@@ -23,7 +23,8 @@ impl ProtocolChain {
         tx_object: TransactionParameters,
         private_key: &SecretKey,
     ) -> Result<SignedTransaction, web3::Error> {
-        self.transport
+        self.web3
+            .accounts()
             .sign_transaction(tx_object, private_key)
             .await
     }
@@ -32,11 +33,17 @@ impl ProtocolChain {
         &self,
         signed_transaction: SignedTransaction,
     ) -> Result<TransactionReceipt, web3::Error> {
-        self.transport.send_transaction(signed_transaction).await
+        self.web3
+            .send_raw_transaction_with_confirmation(
+                signed_transaction.raw_transaction,
+                Duration::from_secs(5), // TODO: set this as a configurable value
+                0,                      // TODO: set this as a configurable value
+            )
+            .await
     }
 
     pub async fn get_latest_block(&self) -> Result<U64, web3::Error> {
-        self.transport.get_latest_block().await
+        self.web3.eth().block_number().await
     }
 
     /// Get a reference to the protocol chain client's chain id.

--- a/packages/oracle/src/transport.rs
+++ b/packages/oracle/src/transport.rs
@@ -39,7 +39,7 @@ impl web3::Transport for JsonRpcExponentialBackoff {
         let http = Arc::clone(&self.inner);
         let op = move || {
             trace!(?id, ?request, "Sending JRPC call");
-            http.send(id.clone(), request.clone())
+            http.send(id, request.clone())
                 .map_err(backoff::Error::transient)
         };
         Box::pin(retry(strategy, op))

--- a/packages/oracle/src/transport.rs
+++ b/packages/oracle/src/transport.rs
@@ -1,0 +1,78 @@
+use backoff::{future::retry, ExponentialBackoff, ExponentialBackoffBuilder};
+use secp256k1::SecretKey;
+use std::time::Duration;
+use tracing::trace;
+use url::Url;
+use web3::{
+    transports::Http,
+    types::{SignedTransaction, TransactionParameters, TransactionReceipt, U64},
+    Web3,
+};
+
+/// A wrapper type around [`Web3`] that supports retries with exponential backoff.
+#[derive(Debug, Clone)]
+pub struct Transport {
+    inner: Web3<Http>,
+    retry_strategy: ExponentialBackoff,
+}
+
+impl Transport {
+    pub fn new(jrpc_url: Url, max_wait_time: Duration) -> Self {
+        // Unwrap: URLs were already parsed and are valid.
+        let transport = Http::new(jrpc_url.as_str()).expect("failed to create HTTP transport");
+        let inner = Web3::new(transport);
+        let retry_strategy = ExponentialBackoffBuilder::new()
+            .with_max_elapsed_time(Some(max_wait_time))
+            .build();
+        Self {
+            inner,
+            retry_strategy,
+        }
+    }
+
+    pub async fn get_latest_block(&self) -> Result<U64, web3::Error> {
+        retry(self.retry_strategy.clone(), || async {
+            trace!("Fetching latest blocks");
+            self.inner
+                .eth()
+                .block_number()
+                .await
+                .map_err(backoff::Error::transient)
+        })
+        .await
+    }
+
+    pub async fn sign_transaction(
+        &self,
+        tx_object: TransactionParameters,
+        private_key: &SecretKey,
+    ) -> Result<SignedTransaction, web3::Error> {
+        retry(self.retry_strategy.clone(), || async {
+            trace!("Signing transaction");
+            self.inner
+                .accounts()
+                .sign_transaction(tx_object.clone(), private_key)
+                .await
+                .map_err(backoff::Error::transient)
+        })
+        .await
+    }
+
+    pub async fn send_transaction(
+        &self,
+        signed_transaction: SignedTransaction,
+    ) -> Result<TransactionReceipt, web3::Error> {
+        retry(self.retry_strategy.clone(), || async {
+            trace!("Sending signed transaction");
+            self.inner
+                .send_raw_transaction_with_confirmation(
+                    signed_transaction.raw_transaction.clone(),
+                    Duration::from_secs(5), // TODO: set this as a configurable value
+                    0,                      // TODO: set this as a configurable value
+                )
+                .await
+                .map_err(backoff::Error::transient)
+        })
+        .await
+    }
+}


### PR DESCRIPTION
Used by `Indexed` and `Protocol` chain structs.

Cloning was necessary for some `web3` and `backoff` crate function calls,
as they won't take their parameters as references.

Fixes #15.