### PR TITLE
Persist network data, fetch block hash, better metrics

### DIFF
--- a/packages/encoding/src/lib.rs
+++ b/packages/encoding/src/lib.rs
@@ -8,7 +8,7 @@ use merkle::{merkle_root, MerkleLeaf};
 use messages::*;
 
 pub use encoding::encode_messages;
-pub use messages::{CompressedMessage, Message};
+pub use messages::{BlockPtr, CompressedMessage, Message};
 
 pub type NetworkId = u64;
 

--- a/packages/oracle/Cargo.toml
+++ b/packages/oracle/Cargo.toml
@@ -11,11 +11,12 @@ ctrlc = "3.2.1"
 envconfig = "0.10.0"
 epoch-encoding = { path = "../encoding" }
 futures = "0.3.21"
+jsonrpc-core = "18.0.0"
 lazy_static = "1"
 prometheus = "0.13.0"
 secp256k1 = "0.21"
 serde = { version = "1.0.136", features = ["derive"] }
-serde_with = { version = "1.1.12" }
+serde_with = "1.1.12"
 sqlx = { version = "0.5", features = ["runtime-tokio-rustls", "sqlite", "migrate", "chrono"] }
 thiserror = "1.0.30"
 tokio = { version = "1", features = ["rt", "macros", "sync"] }

--- a/packages/oracle/config/prod/config.toml
+++ b/packages/oracle/config/prod/config.toml
@@ -1,0 +1,11 @@
+owner_address = "FOO"
+contract_address = "BAR"
+
+json_rpc_polling_interval_in_seconds = 120
+
+[protocol_chain]
+name = "eip155:1"
+jrpc = "https://example.com"
+
+[indexed_chains]
+"spam:42" = "https://example.com"

--- a/packages/oracle/src/emitter.rs
+++ b/packages/oracle/src/emitter.rs
@@ -27,10 +27,6 @@ impl<'a> Emitter<'a> {
         }
     }
 
-    // FIXME:HACK: We will use this to function instead of `epoch_encoder::Blockchain` for two reasons:
-    // 1. using our own `Emitter::Web3` error type
-    // 2. returning a `TransactionReceipt` value, because we need the block hash & number info.
-    // We can refactor thins once we refine our understanting of the encoding crate's interface.
     pub async fn submit_oracle_messages(
         &mut self,
         nonce: u64,
@@ -47,9 +43,9 @@ impl<'a> Emitter<'a> {
             .client
             .sign_transaction(tx_object, self.owner_private_key)
             .await?;
-        debug!(hash = ?signed.transaction_hash, nonce = nonce, "signed transaction");
+        debug!(hash = ?signed.transaction_hash, nonce = nonce, "Signed transaction.");
         let receipt = self.client.send_transaction(signed).await?;
-        info!(hash = ?receipt.transaction_hash, nonce = nonce, "sent transaction");
+        info!(hash = ?receipt.transaction_hash, nonce = nonce, "Sent transaction.");
         Ok(receipt)
     }
 }

--- a/packages/oracle/src/indexed_chain.rs
+++ b/packages/oracle/src/indexed_chain.rs
@@ -1,7 +1,8 @@
-use url::Url;
-use web3::{transports::Http, types::U64, Web3};
-
 use crate::store::Caip2ChainId;
+use epoch_encoding::BlockPtr;
+use tracing::error;
+use url::Url;
+use web3::{transports::Http, Web3};
 
 #[derive(Debug, Clone)]
 pub struct IndexedChain {
@@ -21,7 +22,34 @@ impl IndexedChain {
         &self.chain_id
     }
 
-    pub async fn get_latest_block(&self) -> Result<U64, web3::Error> {
-        self.client.eth().block_number().await
+    pub async fn get_latest_block(&self) -> web3::Result<BlockPtr> {
+        let block_num = self.client.eth().block_number().await?;
+        let block_id = web3::types::BlockId::Number(block_num.into());
+        let block = self
+            .client
+            .eth()
+            .block(block_id)
+            .await?
+            // We were just told that's the latest block number, so it wouldn't
+            // make sense for this to fail. How can it *not* find a block with
+            // that block number?
+            .expect("Invalid block number");
+
+        // Same thing here. We expect data to be consistent across multiple
+        // JSON-RPC calls.
+        if block.number != Some(block_num) {
+            error!(
+                block_num1 = ?block_num,
+                block_num2 = ?block.number,
+                "The JSON-RPC provider is responding to queries with inconsistent data. This is most likely a bug."
+            );
+        }
+        assert_eq!(block.number, Some(block_num));
+        assert!(block.hash.is_some());
+
+        Ok(BlockPtr {
+            number: block_num.as_u64(),
+            hash: block.hash.unwrap().into(),
+        })
     }
 }

--- a/packages/oracle/src/main.rs
+++ b/packages/oracle/src/main.rs
@@ -11,11 +11,15 @@ mod networks_diff;
 mod protocol_chain;
 mod store;
 
-use crate::ctrlc::CtrlcHandler;
+use crate::{
+    ctrlc::CtrlcHandler,
+    store::{Network, WithId},
+};
 use diagnostics::init_logging;
-use epoch_encoding::{self as ee, encode_messages, messages::BlockPtr, CompressionEngine, Message};
+use epoch_encoding::{self as ee, encode_messages, BlockPtr, CompressionEngine, Message};
 use epoch_tracker::EpochTrackerError;
-use event_source::{Event, EventSource};
+use event_source::{EventSource, EventSourceError};
+use futures::future::try_join_all;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use store::{Caip2ChainId, DataEdgeCall};
@@ -33,10 +37,6 @@ lazy_static! {
     pub static ref CONFIG: Config = Config::parse();
     pub static ref METRICS: Metrics = Metrics::default();
     pub static ref CTRLC_HANDLER: CtrlcHandler = CtrlcHandler::init();
-}
-
-struct BlockChainState {
-    latest_block_number: u64,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -77,12 +77,9 @@ async fn main() -> Result<(), Error> {
 
 /// The main application in-memory state
 struct Oracle<'a> {
-    config: &'a Config,
     store: Store,
-    //encoder: Encoder,
     emitter: Emitter<'a>,
     epoch_tracker: EpochTracker,
-    state_by_blockchain: HashMap<Caip2ChainId, BlockChainState>,
     event_source: EventSource,
 }
 
@@ -90,30 +87,32 @@ impl<'a> Oracle<'a> {
     pub fn new(store: Store, config: &'a Config) -> Result<Self, Error> {
         let event_source = EventSource::new(config);
         let emitter = Emitter::new(config);
-        let state_by_blockchain = HashMap::with_capacity(CONFIG.indexed_chains.len());
         let epoch_tracker = EpochTracker::new(&store, &*CONFIG);
 
         Ok(Self {
-            config,
             store,
             event_source,
             emitter,
             epoch_tracker,
-            state_by_blockchain,
         })
     }
 
     pub async fn wait_and_process_next_event(&mut self) -> Result<(), Error> {
-        let event_res = self.event_source.get_latest_protocol_chain_block().await;
-        match event_res {
-            Ok(event) => self.handle_event(event).await,
-            Err(err) => {
-                // Handle event source internal errors
-                use event_source::EventSourceError::*;
+        match self.event_source.get_latest_protocol_chain_block().await {
+            Ok(block_number) => {
+                debug!(
+                    block = %block_number,
+                    "Received latest block information from the protocol chain."
+                );
 
-                match err {
-                    Web3(_) => todo!("decide how should we handle JRPC errors"),
+                if self.is_new_epoch(block_number.as_u64()).await? {
+                    self.handle_new_epoch().await?;
                 }
+
+                Ok(())
+            }
+            Err(EventSourceError::Web3(_)) => {
+                todo!("decide how should we handle JRPC errors")
             }
         }
     }
@@ -134,38 +133,19 @@ impl<'a> Oracle<'a> {
             .collect())
     }
 
-    async fn handle_event(&mut self, event: Event) -> Result<(), Error> {
-        match event {
-            Event::NewBlock {
-                chain_id,
-                block_number,
-            } => {
-                debug!(
-                    network = %chain_id,
-                    block = %block_number,
-                    "Received NewBlock event."
-                );
-
-                if self.is_new_epoch(&chain_id, block_number.as_u64()).await? {
-                    self.handle_new_epoch().await?;
-                }
-
-                Ok(())
-            }
-        }
-    }
-
     async fn handle_new_epoch(&mut self) -> Result<(), Error> {
         info!("A new epoch started in the protocol chain.");
         let mut messages = vec![];
 
+        // First, we need to make sure that there are no pending
+        // `RegisterNetworks` messages.
         let networks_diff = NetworksDiff::calculate(&self.store, &CONFIG).await?;
         info!(
             created = networks_diff.insertions.len(),
             deleted = networks_diff.deletions.len(),
             "Performed indexed chain diffing."
         );
-        if let Some(msg) = networks_diff_to_message(networks_diff) {
+        if let Some(msg) = networks_diff_to_message(&networks_diff) {
             messages.push(msg);
         }
 
@@ -184,113 +164,137 @@ impl<'a> Oracle<'a> {
         let messages = vec![];
 
         compression_engine.compress_messages(&messages[..]);
-        debug!(msg = ?compression_engine.compressed, msg_count = 1u32, "Successfully compressed, now encoding message(s).");
+        debug!(msg = ?compression_engine.compressed, msg_count = messages.len(), "Successfully compressed, now encoding message(s).");
         let encoded = encode_messages(&compression_engine.compressed);
         debug!(encoded = ?encoded, "Successfully encoded message(s).");
         let nonce = self.store.next_nonce().await?;
 
-        self.submit_oracle_messages(nonce, encoded).await?;
+        let data_edge_call = self.submit_oracle_messages(nonce, encoded).await?;
+        let data_edge_call_id = self.store.insert_data_edge_call(data_edge_call).await?;
+        debug!(
+            row_id = data_edge_call_id,
+            "Persisted the call receipt to the database."
+        );
+
+        // Delete all removed networks.
+        try_join_all(
+            networks_diff
+                .deletions
+                .into_iter()
+                .map(|(_, id)| self.store.delete_network(id))
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+        // Persist all newly-created networks.
+        try_join_all(
+            networks_diff
+                .insertions
+                .into_iter()
+                .map(|(name, id)| {
+                    self.store.insert_network(WithId {
+                        id,
+                        data: Network {
+                            name,
+                            latest_block_delta: None,
+                            latest_block_number: None,
+                            latest_block_hash: None,
+                            introduced_with: data_edge_call_id,
+                        },
+                    })
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+        // Finally, update network data with the new block numbers / deltas.
+        try_join_all(
+            compression_engine
+                .network_data_updates
+                .into_iter()
+                .map(|(id, update)| {
+                    let id = u32::try_from(id).unwrap();
+                    self.store
+                        .update_network_block_info_by_id(id, update.block_number)
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+
         Ok(())
     }
 
-    async fn submit_oracle_messages(&mut self, nonce: u64, calldata: Vec<u8>) -> Result<(), Error> {
-        match self
+    async fn submit_oracle_messages(
+        &mut self,
+        nonce: u64,
+        calldata: Vec<u8>,
+    ) -> Result<DataEdgeCall, Error> {
+        let receipt = self
             .emitter
             .submit_oracle_messages(nonce, calldata.clone())
-            .await
-        {
-            Ok(receipt) => {
-                // TODO: After broadcasting a transaction to eip155:1 and getting a
-                // transaction receipt, we should monitor it until it get enough
-                // confirmations. It's unclear which component should do this task.
+            .await?;
 
-                // Record the DataEdge call
-                let data_edge_call: DataEdgeCall = {
-                    // FIXME: The only purpose of this scope is to transform a
-                    // transaction receipt and an encoded payload into a DataEdgeCall
-                    // value. We could refactor it into a dedicated function.
-                    let web3::types::TransactionReceipt {
-                        transaction_hash,
-                        block_hash,
-                        block_number,
-                        ..
-                    } = &receipt;
-                    if let (Some(block_hash), Some(block_number)) = (block_hash, block_number) {
-                        DataEdgeCall::new(
-                            transaction_hash.as_bytes(),
-                            nonce,
-                            block_number.as_u64(),
-                            block_hash.as_bytes(),
-                            calldata,
-                        )
-                    } else {
-                        todo!(
-                            "The expected block number and hash were not present, \
+        // TODO: After broadcasting a transaction to eip155:1 and getting a
+        // transaction receipt, we should monitor it until it get enough
+        // confirmations. It's unclear which component should do this task.
+
+        // FIXME: The only purpose of this scope is to transform a
+        // transaction receipt and an encoded payload into a DataEdgeCall
+        // value. We could refactor it into a dedicated function.
+        let web3::types::TransactionReceipt {
+            transaction_hash,
+            block_hash,
+            block_number,
+            ..
+        } = &receipt;
+        if let (Some(block_hash), Some(block_number)) = (block_hash, block_number) {
+            Ok(DataEdgeCall::new(
+                transaction_hash.as_bytes().to_vec(),
+                nonce,
+                block_number.as_u64(),
+                block_hash.as_bytes().to_vec(),
+                calldata,
+            ))
+        } else {
+            todo!(
+                "The expected block number and hash were not present, \
                                          despite having the transaction receipt at hand. \
                                          We should make an new Error variant out of this."
-                        )
-                    }
-                };
-
-                self.store.insert_data_edge_call(data_edge_call).await?;
-            }
-            Err(other) => return Err(other.into()),
+            )
         }
-
-        Ok(())
     }
 
-    async fn is_new_epoch(
-        &self,
-        chain_id: &Caip2ChainId,
-        block_number: u64,
-    ) -> Result<bool, Error> {
-        let is_protocol_chain = chain_id == self.config.protocol_chain_client.id();
-
-        let is_new_epoch = match self.epoch_tracker.is_new_epoch(block_number).await {
-            Ok(boolean) => boolean,
+    async fn is_new_epoch(&self, block_number: u64) -> Result<bool, Error> {
+        match self.epoch_tracker.is_new_epoch(block_number).await {
+            Ok(b) => Ok(b),
             Err(EpochTrackerError::PreviousEpochNotFound) => {
                 // FIXME: At the moment, we are unable to determine the latest epoch from an
                 // empty state. Until the Oracle is capable of reacting upon that, we will
                 // consider that we have reached a new epoch in such cases.
                 warn!("Failed to determine the previous epoch.");
-                true
+                Ok(true)
             }
-            Err(other_error) => return Err(other_error.into()),
-        };
-
-        Ok(is_protocol_chain && is_new_epoch)
+            Err(other_error) => Err(other_error.into()),
+        }
     }
 }
 
-fn latest_blocks_to_message(
-    latest_blocks: HashMap<&Caip2ChainId, web3::types::U64>,
-) -> ee::Message {
+fn latest_blocks_to_message(latest_blocks: HashMap<&Caip2ChainId, BlockPtr>) -> ee::Message {
     Message::SetBlockNumbersForNextEpoch(
         latest_blocks
             .iter()
-            .map(|(chain_id, block_number)| {
-                (
-                    chain_id.as_str().to_owned(),
-                    BlockPtr {
-                        number: block_number.as_u64(),
-                        hash: [0u8; 32], // FIXME
-                    },
-                )
-            })
+            .map(|(chain_id, block_ptr)| (chain_id.as_str().to_owned(), *block_ptr))
             .collect(),
     )
 }
 
-fn networks_diff_to_message(diff: NetworksDiff) -> Option<ee::Message> {
+fn networks_diff_to_message(diff: &NetworksDiff) -> Option<ee::Message> {
     if diff.deletions.is_empty() && diff.insertions.is_empty() {
         None
     } else {
         Some(ee::Message::RegisterNetworks {
-            remove: diff.deletions.into_iter().map(|x| x.1 as u64).collect(),
+            remove: diff.deletions.iter().map(|x| *x.1 as u64).collect(),
             add: diff
                 .insertions
-                .into_iter()
+                .iter()
                 .map(|x| x.0.as_str().to_string())
                 .collect(),
         })

--- a/packages/oracle/src/metrics.rs
+++ b/packages/oracle/src/metrics.rs
@@ -1,7 +1,11 @@
 use prometheus::*;
 
+#[derive(Debug, Clone)]
 pub struct Metrics {
     registry: Registry,
+
+    pub db_queries: Counter,
+    pub retries_by_jsonrpc_provider: HistogramVec,
 }
 
 impl Metrics {
@@ -17,6 +21,25 @@ impl Metrics {
 impl Default for Metrics {
     fn default() -> Self {
         let r = Registry::new();
-        Self { registry: r }
+
+        let db_queries = Counter::new("db_queries", "Number of database queries").unwrap();
+        let retries_by_jsonrpc_provider = HistogramVec::new(
+            HistogramOpts::new(
+                "retries_by_jsonrpc_provider",
+                "Number of JSON-RPC request retries.",
+            ),
+            &["jsonrpc_provider"],
+        )
+        .unwrap();
+
+        r.register(Box::new(db_queries.clone())).unwrap();
+        r.register(Box::new(retries_by_jsonrpc_provider.clone()))
+            .unwrap();
+
+        Self {
+            registry: r,
+            db_queries,
+            retries_by_jsonrpc_provider,
+        }
     }
 }

--- a/packages/oracle/src/store/models.rs
+++ b/packages/oracle/src/store/models.rs
@@ -82,22 +82,22 @@ pub struct Network {
 }
 
 #[derive(Debug, Clone)]
-pub struct DataEdgeCall<'a> {
-    pub tx_hash: &'a [u8],
+pub struct DataEdgeCall {
+    pub tx_hash: Vec<u8>,
     pub nonce: u64,
     pub num_confirmations: u64,
     pub num_confirmations_last_checked_at: Timestamp,
     pub block_number: BlockNumber,
-    pub block_hash: &'a [u8],
+    pub block_hash: Vec<u8>,
     pub payload: Vec<u8>,
 }
 
-impl<'a> DataEdgeCall<'a> {
+impl DataEdgeCall {
     pub fn new(
-        tx_hash: &'a [u8],
+        tx_hash: Vec<u8>,
         nonce: u64,
         block_number: BlockNumber,
-        block_hash: &'a [u8],
+        block_hash: Vec<u8>,
         payload: Vec<u8>,
     ) -> Self {
         Self {

--- a/packages/oracle/src/store/store.rs
+++ b/packages/oracle/src/store/store.rs
@@ -98,6 +98,15 @@ VALUES (?1, ?2)"#,
         Ok(())
     }
 
+    pub async fn delete_network(&self, network_id: models::Id) -> sqlx::Result<()> {
+        sqlx::query("DELETE FROM networks WHERE id = ?1")
+            .bind(i32::try_from(network_id).unwrap())
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn insert_network(
         &self,
         network: WithId<models::Network>,
@@ -199,9 +208,9 @@ ORDER BY id ASC"#,
         Ok(networks)
     }
 
-    pub async fn insert_data_edge_call<'a>(
+    pub async fn insert_data_edge_call(
         &self,
-        call: models::DataEdgeCall<'a>,
+        call: models::DataEdgeCall,
     ) -> sqlx::Result<models::Id> {
         let row: (i32,) = sqlx::query_as(
             r#"


### PR DESCRIPTION
- After every iteration in the main loop, we now persist the latest network deltas and block number.
- Removed the `enum Event` definition. I think it would make sense to reintroduce it if we had some sort of `next_event` method, but as long as we're only polling for the latest protocol chain block, we don't need it.
- More Prometheus metrics.
- We now have the latest block hash of all indexed chains.

This is my last big PR, now that we're getting to a more mature stage of the project, I'll try to keep contributions small and focused :) 