### PR TITLE
Sync Rust team's branch with the latest subgraph PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ cached/
 # Ignore solc bin output
 bin/
 
+# Ignore matchstick bin output
+.bin/
+
 # Others
 .env
 .DS_Store

--- a/packages/subgraph/abis/DataEdgeFull.json
+++ b/packages/subgraph/abis/DataEdgeFull.json
@@ -1,0 +1,19 @@
+[
+  {
+    "stateMutability": "nonpayable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "crossChainEpochOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "prepare": "./scripts/prepare.sh",
     "codegen": "graph codegen",
+    "test": "graph test",
     "build": "yarn prepare && graph build",
     "deploy": "graph deploy --node https://api.thegraph.com/deploy/ juanmardefago/block-oracle",
     "create-local": "graph create --node http://localhost:8020/ abarmat/block-oracle",
@@ -13,5 +14,8 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "0.27.0",
     "@graphprotocol/graph-ts": "0.24.1"
+  },
+  "devDependencies": {
+    "matchstick-as": "^0.4.1"
   }
 }

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -12,8 +12,8 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 abarmat/block-oracle"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.27.0",
-    "@graphprotocol/graph-ts": "0.24.1"
+    "@graphprotocol/graph-cli": "0.29.0",
+    "@graphprotocol/graph-ts": "0.26.0"
   },
   "devDependencies": {
     "matchstick-as": "^0.4.1"

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -5,7 +5,7 @@
     "prepare": "./scripts/prepare.sh",
     "codegen": "graph codegen",
     "build": "yarn prepare && graph build",
-    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ abarmat/block-oracle",
+    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ juanmardefago/block-oracle",
     "create-local": "graph create --node http://localhost:8020/ abarmat/block-oracle",
     "remove-local": "graph remove --node http://localhost:8020/ abarmat/block-oracle",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 abarmat/block-oracle"

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -20,25 +20,26 @@ type MessageBlock @entity {
 interface Message {
   id: ID!
   block: MessageBlock!
-  data: Bytes!
+  "data is optional since it might be an empty message"
+  data: Bytes
 }
 
 type SetBlockNumbersForEpochMessage implements Message @entity {
   id: ID!
   block: MessageBlock!
-  data: Bytes!
+  data: Bytes
 }
 
 type CorrectEpochsMessage implements Message @entity {
   id: ID!
   block: MessageBlock!
-  data: Bytes!
+  data: Bytes
 }
 
 type UpdateVersionsMessage implements Message @entity {
   id: ID!
   block: MessageBlock!
-  data: Bytes!
+  data: Bytes
 }
 
 type RegisterNetworksMessage implements Message @entity {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -59,10 +59,27 @@ type Network @entity {
   chainID: String!
   addedAt: RegisterNetworksMessage!
   removedAt: RegisterNetworksMessage
+  blockNumbers: [NetworkEpochBlockNumber!]! @derivedFrom(field:"network")
 }
 
 type GlobalState @entity {
   id: ID!
   networkCount: Int!
   activeNetworkCount: Int!
+  latestValidEpoch: Epoch
+}
+
+type Epoch @entity {
+  id: ID!
+  epochNumber: BigInt!
+  blockNumbers: [NetworkEpochBlockNumber!]! @derivedFrom(field:"epoch")
+}
+
+type NetworkEpochBlockNumber @entity {
+  id: ID!
+  acceleration: BigInt!
+  delta: BigInt!
+  blockNumber: BigInt!
+  network: Network!
+  epoch: Epoch!
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -28,6 +28,8 @@ type SetBlockNumbersForEpochMessage implements Message @entity {
   id: ID!
   block: MessageBlock!
   data: Bytes
+  merkleRoot: Bytes
+  accelerations: [BigInt!]
 }
 
 type CorrectEpochsMessage implements Message @entity {
@@ -45,14 +47,22 @@ type UpdateVersionsMessage implements Message @entity {
 type RegisterNetworksMessage implements Message @entity {
   id: ID!
   block: MessageBlock!
-  data: Bytes!
+  data: Bytes
+  removeCount: BigInt!
+  addCount: BigInt!
+  networksRemoved: [Network!]! @derivedFrom(field: "removedAt")
+  networksAdded: [Network!]! @derivedFrom(field: "addedAt")
 }
 
 type Network @entity {
   id: ID!
+  chainID: String!
+  addedAt: RegisterNetworksMessage!
+  removedAt: RegisterNetworksMessage
 }
 
 type GlobalState @entity {
   id: ID!
-  networkCount: BigInt!
+  networkCount: Int!
+  activeNetworkCount: Int!
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -3,8 +3,22 @@ type DataEdge @entity {
   owner: Bytes!
 }
 
-type Message @entity {
+type MessageBlock @entity {
   id: ID!
   data: Bytes!
   submitter: String!
+  messages: [Message!]! @derivedFrom(field: "block")
+}
+
+type Message @entity {
+  id: ID!
+  type: MessageType!
+  block: MessageBlock!
+}
+
+enum MessageType {
+  SetBlockNumbersForEpoch
+  CorrectEpochs
+  UpdateVersions
+  RegisterNetworks
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -3,22 +3,55 @@ type DataEdge @entity {
   owner: Bytes!
 }
 
-type MessageBlock @entity {
+type Payload @entity {
   id: ID!
   data: Bytes!
   submitter: String!
+  messageBlocks: [MessageBlock!]! @derivedFrom(field: "payload")
+}
+
+type MessageBlock @entity {
+  id: ID!
+  data: Bytes!
+  payload: Payload!
   messages: [Message!]! @derivedFrom(field: "block")
 }
 
-type Message @entity {
+interface Message {
   id: ID!
-  type: MessageType!
   block: MessageBlock!
+  data: Bytes!
 }
 
-enum MessageType {
-  SetBlockNumbersForEpoch
-  CorrectEpochs
-  UpdateVersions
-  RegisterNetworks
+type SetBlockNumbersForEpochMessage implements Message @entity {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes!
+}
+
+type CorrectEpochsMessage implements Message @entity {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes!
+}
+
+type UpdateVersionsMessage implements Message @entity {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes!
+}
+
+type RegisterNetworksMessage implements Message @entity {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes!
+}
+
+type Network @entity {
+  id: ID!
+}
+
+type GlobalState @entity {
+  id: ID!
+  networkCount: BigInt!
 }

--- a/packages/subgraph/src/constants.ts
+++ b/packages/subgraph/src/constants.ts
@@ -1,2 +1,6 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
 export const PREAMBLE_BIT_LENGTH = 8;
 export const TAG_BIT_LENGTH = 2;
+export let BIGINT_ZERO = BigInt.fromI32(0);
+export let BIGINT_ONE = BigInt.fromI32(1);

--- a/packages/subgraph/src/constants.ts
+++ b/packages/subgraph/src/constants.ts
@@ -1,6 +1,2 @@
-export const SET_BLOCK_NUMBERS_FOR_EPOCH = "SetBlockNumbersForEpoch"
-export const CORRECT_EPOCHS = "CorrectEpochs"
-export const UPDATE_VERSIONS = "UpdateVersions"
-export const REGISTER_NETWORKS = "RegisterNetworks"
 export const PREAMBLE_BIT_LENGTH = 8
 export const TAG_BIT_LENGTH = 2

--- a/packages/subgraph/src/constants.ts
+++ b/packages/subgraph/src/constants.ts
@@ -1,2 +1,2 @@
-export const PREAMBLE_BIT_LENGTH = 8
-export const TAG_BIT_LENGTH = 2
+export const PREAMBLE_BIT_LENGTH = 8;
+export const TAG_BIT_LENGTH = 2;

--- a/packages/subgraph/src/constants.ts
+++ b/packages/subgraph/src/constants.ts
@@ -1,0 +1,6 @@
+export const SET_BLOCK_NUMBERS_FOR_EPOCH = "SetBlockNumbersForEpoch"
+export const CORRECT_EPOCHS = "CorrectEpochs"
+export const UPDATE_VERSIONS = "UpdateVersions"
+export const REGISTER_NETWORKS = "RegisterNetworks"
+export const PREAMBLE_BIT_LENGTH = 8
+export const TAG_BIT_LENGTH = 2

--- a/packages/subgraph/src/helpers.ts
+++ b/packages/subgraph/src/helpers.ts
@@ -1,0 +1,171 @@
+import { Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { GlobalState } from "../generated/schema";
+import {
+  SET_BLOCK_NUMBERS_FOR_EPOCH,
+  CORRECT_EPOCHS,
+  UPDATE_VERSIONS,
+  REGISTER_NETWORKS,
+  PREAMBLE_BIT_LENGTH,
+  TAG_BIT_LENGTH
+} from "./constants";
+
+export function getGlobalState(): GlobalState {
+  let state = GlobalState.load("0");
+  if (state == null) {
+    state = new GlobalState("0");
+    state.save();
+  }
+  return state;
+}
+
+export function getTags(preamble: Bytes): Array<String> {
+  let tags = new Array<String>();
+  for (let i = 0; i < PREAMBLE_BIT_LENGTH / TAG_BIT_LENGTH; i++) {
+    tags.push(getTag(preamble, i));
+  }
+  return tags;
+}
+
+function getTag(preamble: Bytes, index: i32): i32 {
+  return (
+    (BigInt.fromUnsignedBytes(preamble).toI32() >> (index * TAG_BIT_LENGTH)) &
+    (2 ** TAG_BIT_LENGTH - 1)
+  );
+}
+
+/*
+Prefix Varint decode rust example
+
+#[cfg(feature = "decode")]
+pub fn decode_prefix_varint(bytes: &[u8], offset: &mut usize) -> DecodeResult<u64> {
+    // TODO: (Performance) When reading from an array, a series of values can be decoded unchecked.
+    // Eg: If there are 100 bytes, each number taken can read at most 9 bytes,
+    // so 11 values can be taken unchecked (up to 99 bytes). This will likely read less,
+    // so this can remain in an amortized check loop until the size of the remainder
+    // is less than 9 bytes.
+
+    let first = bytes.get(*offset).ok_or_else(|| DecodeError::InvalidFormat)?;
+    let shift = first.trailing_zeros();
+
+    // TODO: Check that the compiler does unchecked indexing after this
+    if (*offset + (shift as usize)) >= bytes.len() {
+        return Err(DecodeError::InvalidFormat);
+    }
+
+    let result = match shift {
+        0 => (first >> 1) as u64,
+        1 => (first >> 2) as u64 | ((bytes[*offset + 1] as u64) << 6),
+        2 => (first >> 3) as u64 | ((bytes[*offset + 1] as u64) << 5) | ((bytes[*offset + 2] as u64) << 13),
+        3 => (first >> 4) as u64 | ((bytes[*offset + 1] as u64) << 4) | ((bytes[*offset + 2] as u64) << 12) | ((bytes[*offset + 3] as u64) << 20),
+        4 => {
+            (first >> 5) as u64
+                | ((bytes[*offset + 1] as u64) << 3)
+                | ((bytes[*offset + 2] as u64) << 11)
+                | ((bytes[*offset + 3] as u64) << 19)
+                | ((bytes[*offset + 4] as u64) << 27)
+        }
+        5 => {
+            (first >> 6) as u64
+                | ((bytes[*offset + 1] as u64) << 2)
+                | ((bytes[*offset + 2] as u64) << 10)
+                | ((bytes[*offset + 3] as u64) << 18)
+                | ((bytes[*offset + 4] as u64) << 26)
+                | ((bytes[*offset + 5] as u64) << 34)
+        }
+        6 => {
+            (first >> 7) as u64
+                | ((bytes[*offset + 1] as u64) << 1)
+                | ((bytes[*offset + 2] as u64) << 9)
+                | ((bytes[*offset + 3] as u64) << 17)
+                | ((bytes[*offset + 4] as u64) << 25)
+                | ((bytes[*offset + 5] as u64) << 33)
+                | ((bytes[*offset + 6] as u64) << 41)
+        }
+        7 => {
+            (bytes[*offset + 1] as u64)
+                | ((bytes[*offset + 2] as u64) << 8)
+                | ((bytes[*offset + 3] as u64) << 16)
+                | ((bytes[*offset + 4] as u64) << 24)
+                | ((bytes[*offset + 5] as u64) << 32)
+                | ((bytes[*offset + 6] as u64) << 40)
+                | ((bytes[*offset + 7] as u64) << 48)
+        }
+        8 => {
+            (bytes[*offset + 1] as u64)
+                | ((bytes[*offset + 2] as u64) << 8)
+                | ((bytes[*offset + 3] as u64) << 16)
+                | ((bytes[*offset + 4] as u64) << 24)
+                | ((bytes[*offset + 5] as u64) << 32)
+                | ((bytes[*offset + 6] as u64) << 40)
+                | ((bytes[*offset + 7] as u64) << 48)
+                | ((bytes[*offset + 8] as u64) << 56)
+        }
+        _ => unreachable!(),
+    };
+    *offset += (shift + 1) as usize;
+    Ok(result)
+}
+*/
+
+export function decodePrefixVarIntI64(bytes: Bytes, offset: u32): i64 {}
+
+export function decodePrefixVarIntU64(bytes: Bytes, offset: u32): u64 {
+  let first = bytes[offset];
+  let shift = first.toString(2);
+
+  // // TODO: Check that the compiler does unchecked indexing after this
+  // if (*offset + (shift as usize)) >= bytes.len() {
+  //     return Err(DecodeError::InvalidFormat);
+  // }
+
+  let result = 0 as u64;
+  if (shift == "00000000") {
+    result = (bytes[offset + 1] as u64)
+        | ((bytes[offset + 2] as u64) << 8)
+        | ((bytes[offset + 3] as u64) << 16)
+        | ((bytes[offset + 4] as u64) << 24)
+        | ((bytes[offset + 5] as u64) << 32)
+        | ((bytes[offset + 6] as u64) << 40)
+        | ((bytes[offset + 7] as u64) << 48)
+        | ((bytes[offset + 8] as u64) << 56)
+  } else if (shift.endsWith("0000000")) {
+    result = (bytes[offset + 1] as u64)
+        | ((bytes[offset + 2] as u64) << 8)
+        | ((bytes[offset + 3] as u64) << 16)
+        | ((bytes[offset + 4] as u64) << 24)
+        | ((bytes[offset + 5] as u64) << 32)
+        | ((bytes[offset + 6] as u64) << 40)
+        | ((bytes[offset + 7] as u64) << 48)
+  } else if (shift.endsWith("000000")) {
+    result = (first >> 7) as u64
+        | ((bytes[offset + 1] as u64) << 1)
+        | ((bytes[offset + 2] as u64) << 9)
+        | ((bytes[offset + 3] as u64) << 17)
+        | ((bytes[offset + 4] as u64) << 25)
+        | ((bytes[offset + 5] as u64) << 33)
+        | ((bytes[offset + 6] as u64) << 41)
+  } else if (shift.endsWith("00000")) {
+    result = (first >> 6) as u64
+        | ((bytes[offset + 1] as u64) << 2)
+        | ((bytes[offset + 2] as u64) << 10)
+        | ((bytes[offset + 3] as u64) << 18)
+        | ((bytes[offset + 4] as u64) << 26)
+        | ((bytes[offset + 5] as u64) << 34)
+  } else if (shift.endsWith("0000")) {
+    result = (first >> 5) as u64
+        | ((bytes[offset + 1] as u64) << 3)
+        | ((bytes[offset + 2] as u64) << 11)
+        | ((bytes[offset + 3] as u64) << 19)
+        | ((bytes[offset + 4] as u64) << 27)
+  } else if (shift.endsWith("000")) {
+    result = (first >> 4) as u64 | ((bytes[offset + 1] as u64) << 4) | ((bytes[offset + 2] as u64) << 12) | ((bytes[offset + 3] as u64) << 20)
+  } else if (shift.endsWith("00")) {
+    result = (first >> 3) as u64 | ((bytes[offset + 1] as u64) << 5) | ((bytes[offset + 2] as u64) << 13)
+  } else if (shift.endsWith("0")) {
+    result = (first >> 2) as u64 | ((bytes[offset + 1] as u64) << 6)
+  } else {
+    result = (first >> 1) as u64
+  }
+
+  return result;
+}

--- a/packages/subgraph/src/helpers.ts
+++ b/packages/subgraph/src/helpers.ts
@@ -104,72 +104,62 @@ export function decodePrefixVarIntI64(bytes: Bytes, offset: u32): i64 {}
 
 export function decodePrefixVarIntU64(bytes: Bytes, offset: u32): u64 {
   let first = bytes[offset];
-  let shift = first.toString(2);
+  let shift = ctz(first);
 
   // // TODO: Check that the compiler does unchecked indexing after this
   // if (*offset + (shift as usize)) >= bytes.len() {
   //     return Err(DecodeError::InvalidFormat);
   // }
 
+
+
   let result: u64;
-  if (shift == "00000000") {
-    result =
-      (bytes[offset + 1] as u64) |
-      ((bytes[offset + 2] as u64) << 8) |
-      ((bytes[offset + 3] as u64) << 16) |
-      ((bytes[offset + 4] as u64) << 24) |
-      ((bytes[offset + 5] as u64) << 32) |
-      ((bytes[offset + 6] as u64) << 40) |
-      ((bytes[offset + 7] as u64) << 48) |
-      ((bytes[offset + 8] as u64) << 56);
-  } else if (shift.endsWith("0000000")) {
-    result =
-      (bytes[offset + 1] as u64) |
-      ((bytes[offset + 2] as u64) << 8) |
-      ((bytes[offset + 3] as u64) << 16) |
-      ((bytes[offset + 4] as u64) << 24) |
-      ((bytes[offset + 5] as u64) << 32) |
-      ((bytes[offset + 6] as u64) << 40) |
-      ((bytes[offset + 7] as u64) << 48);
-  } else if (shift.endsWith("000000")) {
-    result =
-      ((first >> 7) as u64) |
-      ((bytes[offset + 1] as u64) << 1) |
-      ((bytes[offset + 2] as u64) << 9) |
-      ((bytes[offset + 3] as u64) << 17) |
-      ((bytes[offset + 4] as u64) << 25) |
-      ((bytes[offset + 5] as u64) << 33) |
-      ((bytes[offset + 6] as u64) << 41);
-  } else if (shift.endsWith("00000")) {
-    result =
-      ((first >> 6) as u64) |
-      ((bytes[offset + 1] as u64) << 2) |
-      ((bytes[offset + 2] as u64) << 10) |
-      ((bytes[offset + 3] as u64) << 18) |
-      ((bytes[offset + 4] as u64) << 26) |
-      ((bytes[offset + 5] as u64) << 34);
-  } else if (shift.endsWith("0000")) {
-    result =
-      ((first >> 5) as u64) |
-      ((bytes[offset + 1] as u64) << 3) |
-      ((bytes[offset + 2] as u64) << 11) |
-      ((bytes[offset + 3] as u64) << 19) |
-      ((bytes[offset + 4] as u64) << 27);
-  } else if (shift.endsWith("000")) {
-    result =
-      ((first >> 4) as u64) |
-      ((bytes[offset + 1] as u64) << 4) |
-      ((bytes[offset + 2] as u64) << 12) |
-      ((bytes[offset + 3] as u64) << 20);
-  } else if (shift.endsWith("00")) {
-    result =
-      ((first >> 3) as u64) |
-      ((bytes[offset + 1] as u64) << 5) |
-      ((bytes[offset + 2] as u64) << 13);
-  } else if (shift.endsWith("0")) {
-    result = ((first >> 2) as u64) | ((bytes[offset + 1] as u64) << 6);
-  } else {
-    result = (first >> 1) as u64;
+  if(shift == 0) {
+    result = ((first >> 1) as u64)
+  } else if(shift == 1) {
+    result  = (((first >> 2) as u64) | ((bytes[offset + 1] as u64) << 6))
+  } else if(shift == 2) {
+    result = (((first >> 3) as u64) | ((bytes[offset + 1] as u64) << 5) | ((bytes[offset + 2] as u64) << 13))
+  } else if(shift == 3) {
+    result = (((first >> 4) as u64) | ((bytes[offset + 1] as u64) << 4) | ((bytes[offset + 2] as u64) << 12) | ((bytes[offset + 3] as u64) << 20))
+  } else if(shift == 4) {
+    result = (((first >> 5) as u64)
+        | ((bytes[offset + 1] as u64) << 3)
+        | ((bytes[offset + 2] as u64) << 11)
+        | ((bytes[offset + 3] as u64) << 19)
+        | ((bytes[offset + 4] as u64) << 27))
+  } else if(shift == 5) {
+    result = (((first >> 6) as u64)
+        | ((bytes[offset + 1] as u64) << 2)
+        | ((bytes[offset + 2] as u64) << 10)
+        | ((bytes[offset + 3] as u64) << 18)
+        | ((bytes[offset + 4] as u64) << 26)
+        | ((bytes[offset + 5] as u64) << 34))
+  } else if(shift == 6) {
+    result = (((first >> 7) as u64)
+        | ((bytes[offset + 1] as u64) << 1)
+        | ((bytes[offset + 2] as u64) << 9)
+        | ((bytes[offset + 3] as u64) << 17)
+        | ((bytes[offset + 4] as u64) << 25)
+        | ((bytes[offset + 5] as u64) << 33)
+        | ((bytes[offset + 6] as u64) << 41))
+  } else if(shift == 7) {
+    result = ((bytes[offset + 1] as u64)
+        | ((bytes[offset + 2] as u64) << 8)
+        | ((bytes[offset + 3] as u64) << 16)
+        | ((bytes[offset + 4] as u64) << 24)
+        | ((bytes[offset + 5] as u64) << 32)
+        | ((bytes[offset + 6] as u64) << 40)
+        | ((bytes[offset + 7] as u64) << 48))
+  } else if(shift == 8) {
+    result = ((bytes[offset + 1] as u64)
+        | ((bytes[offset + 2] as u64) << 8)
+        | ((bytes[offset + 3] as u64) << 16)
+        | ((bytes[offset + 4] as u64) << 24)
+        | ((bytes[offset + 5] as u64) << 32)
+        | ((bytes[offset + 6] as u64) << 40)
+        | ((bytes[offset + 7] as u64) << 48)
+        | ((bytes[offset + 8] as u64) << 56))
   }
 
   return result;

--- a/packages/subgraph/src/helpers.ts
+++ b/packages/subgraph/src/helpers.ts
@@ -29,14 +29,15 @@ function getTag(preamble: Bytes, index: i32): i32 {
 
 // Returns the decoded i64 and the amount of bytes read. [0,0] -> Error
 export function decodePrefixVarIntI64(bytes: Bytes, offset: u32): Array<i64> {
-  let result: Array<i64> = [0,0];
+  let result: i64 = 0;
+
   // First we need to decode the raw bytes into a u64 and check that it didn't error out
   let zigZagDecodeInput = decodePrefixVarIntU64(bytes, offset)
   if(zigZagDecodeInput[1] != 0) {
     // Then we need to decode the U64 with ZigZag
     result = zigZagDecode(zigZagDecodeInput[0])
   }
-  return result
+  return [result, zigZagDecodeInput[1]]
 }
 
 // Returns the decoded u64 and the amount of bytes read. [0,0] -> Error
@@ -114,7 +115,6 @@ export function decodePrefixVarIntU64(bytes: Bytes, offset: u32): Array<u64> {
   return [result, shift + 1];
 }
 
-// Returns the decoded u64 and the amount of bytes read. [0,0] -> Error
 export function zigZagDecode(input: u64): i64 {
   return ((input >> 1) ^ -(input & 1)) as i64
 }

--- a/packages/subgraph/src/helpers.ts
+++ b/packages/subgraph/src/helpers.ts
@@ -1,13 +1,6 @@
 import { Bytes, BigInt } from "@graphprotocol/graph-ts";
 import { GlobalState } from "../generated/schema";
-import {
-  SET_BLOCK_NUMBERS_FOR_EPOCH,
-  CORRECT_EPOCHS,
-  UPDATE_VERSIONS,
-  REGISTER_NETWORKS,
-  PREAMBLE_BIT_LENGTH,
-  TAG_BIT_LENGTH
-} from "./constants";
+import { PREAMBLE_BIT_LENGTH, TAG_BIT_LENGTH } from "./constants";
 
 export function getGlobalState(): GlobalState {
   let state = GlobalState.load("0");
@@ -18,8 +11,8 @@ export function getGlobalState(): GlobalState {
   return state;
 }
 
-export function getTags(preamble: Bytes): Array<String> {
-  let tags = new Array<String>();
+export function getTags(preamble: Bytes): Array<i32> {
+  let tags = new Array<i32>();
   for (let i = 0; i < PREAMBLE_BIT_LENGTH / TAG_BIT_LENGTH; i++) {
     tags.push(getTag(preamble, i));
   }
@@ -118,53 +111,65 @@ export function decodePrefixVarIntU64(bytes: Bytes, offset: u32): u64 {
   //     return Err(DecodeError::InvalidFormat);
   // }
 
-  let result = 0 as u64;
+  let result: u64;
   if (shift == "00000000") {
-    result = (bytes[offset + 1] as u64)
-        | ((bytes[offset + 2] as u64) << 8)
-        | ((bytes[offset + 3] as u64) << 16)
-        | ((bytes[offset + 4] as u64) << 24)
-        | ((bytes[offset + 5] as u64) << 32)
-        | ((bytes[offset + 6] as u64) << 40)
-        | ((bytes[offset + 7] as u64) << 48)
-        | ((bytes[offset + 8] as u64) << 56)
+    result =
+      (bytes[offset + 1] as u64) |
+      ((bytes[offset + 2] as u64) << 8) |
+      ((bytes[offset + 3] as u64) << 16) |
+      ((bytes[offset + 4] as u64) << 24) |
+      ((bytes[offset + 5] as u64) << 32) |
+      ((bytes[offset + 6] as u64) << 40) |
+      ((bytes[offset + 7] as u64) << 48) |
+      ((bytes[offset + 8] as u64) << 56);
   } else if (shift.endsWith("0000000")) {
-    result = (bytes[offset + 1] as u64)
-        | ((bytes[offset + 2] as u64) << 8)
-        | ((bytes[offset + 3] as u64) << 16)
-        | ((bytes[offset + 4] as u64) << 24)
-        | ((bytes[offset + 5] as u64) << 32)
-        | ((bytes[offset + 6] as u64) << 40)
-        | ((bytes[offset + 7] as u64) << 48)
+    result =
+      (bytes[offset + 1] as u64) |
+      ((bytes[offset + 2] as u64) << 8) |
+      ((bytes[offset + 3] as u64) << 16) |
+      ((bytes[offset + 4] as u64) << 24) |
+      ((bytes[offset + 5] as u64) << 32) |
+      ((bytes[offset + 6] as u64) << 40) |
+      ((bytes[offset + 7] as u64) << 48);
   } else if (shift.endsWith("000000")) {
-    result = (first >> 7) as u64
-        | ((bytes[offset + 1] as u64) << 1)
-        | ((bytes[offset + 2] as u64) << 9)
-        | ((bytes[offset + 3] as u64) << 17)
-        | ((bytes[offset + 4] as u64) << 25)
-        | ((bytes[offset + 5] as u64) << 33)
-        | ((bytes[offset + 6] as u64) << 41)
+    result =
+      ((first >> 7) as u64) |
+      ((bytes[offset + 1] as u64) << 1) |
+      ((bytes[offset + 2] as u64) << 9) |
+      ((bytes[offset + 3] as u64) << 17) |
+      ((bytes[offset + 4] as u64) << 25) |
+      ((bytes[offset + 5] as u64) << 33) |
+      ((bytes[offset + 6] as u64) << 41);
   } else if (shift.endsWith("00000")) {
-    result = (first >> 6) as u64
-        | ((bytes[offset + 1] as u64) << 2)
-        | ((bytes[offset + 2] as u64) << 10)
-        | ((bytes[offset + 3] as u64) << 18)
-        | ((bytes[offset + 4] as u64) << 26)
-        | ((bytes[offset + 5] as u64) << 34)
+    result =
+      ((first >> 6) as u64) |
+      ((bytes[offset + 1] as u64) << 2) |
+      ((bytes[offset + 2] as u64) << 10) |
+      ((bytes[offset + 3] as u64) << 18) |
+      ((bytes[offset + 4] as u64) << 26) |
+      ((bytes[offset + 5] as u64) << 34);
   } else if (shift.endsWith("0000")) {
-    result = (first >> 5) as u64
-        | ((bytes[offset + 1] as u64) << 3)
-        | ((bytes[offset + 2] as u64) << 11)
-        | ((bytes[offset + 3] as u64) << 19)
-        | ((bytes[offset + 4] as u64) << 27)
+    result =
+      ((first >> 5) as u64) |
+      ((bytes[offset + 1] as u64) << 3) |
+      ((bytes[offset + 2] as u64) << 11) |
+      ((bytes[offset + 3] as u64) << 19) |
+      ((bytes[offset + 4] as u64) << 27);
   } else if (shift.endsWith("000")) {
-    result = (first >> 4) as u64 | ((bytes[offset + 1] as u64) << 4) | ((bytes[offset + 2] as u64) << 12) | ((bytes[offset + 3] as u64) << 20)
+    result =
+      ((first >> 4) as u64) |
+      ((bytes[offset + 1] as u64) << 4) |
+      ((bytes[offset + 2] as u64) << 12) |
+      ((bytes[offset + 3] as u64) << 20);
   } else if (shift.endsWith("00")) {
-    result = (first >> 3) as u64 | ((bytes[offset + 1] as u64) << 5) | ((bytes[offset + 2] as u64) << 13)
+    result =
+      ((first >> 3) as u64) |
+      ((bytes[offset + 1] as u64) << 5) |
+      ((bytes[offset + 2] as u64) << 13);
   } else if (shift.endsWith("0")) {
-    result = (first >> 2) as u64 | ((bytes[offset + 1] as u64) << 6)
+    result = ((first >> 2) as u64) | ((bytes[offset + 1] as u64) << 6);
   } else {
-    result = (first >> 1) as u64
+    result = (first >> 1) as u64;
   }
 
   return result;

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -1,12 +1,22 @@
 import { CrossChainEpochOracleCall } from "../generated/DataEdge/DataEdge";
 import { Bytes, BigInt } from "@graphprotocol/graph-ts";
-import { DataEdge, Message, MessageBlock, Payload } from "../generated/schema";
+import {
+  DataEdge,
+  SetBlockNumbersForEpochMessage,
+  CorrectEpochsMessage,
+  UpdateVersionsMessage,
+  RegisterNetworksMessage,
+  MessageBlock,
+  Payload,
+  GlobalState
+} from "../generated/schema";
 import {
   getGlobalState,
   getTags,
   decodePrefixVarIntU64,
   decodePrefixVarIntI64
 } from "./helpers";
+import { PREAMBLE_BIT_LENGTH, TAG_BIT_LENGTH } from "./constants";
 
 export function handleCrossChainEpochOracle(
   call: CrossChainEpochOracleCall
@@ -58,9 +68,9 @@ function executeMessage(
 ): void {
   // ToDo, parse and actually execute message
   let message = new SetBlockNumbersForEpochMessage(
-    [messageBlockID, BigInt.fromI32(i).toString()].join("-")
+    [messageBlockID, BigInt.fromI32(index).toString()].join("-")
   );
-  message.block = messageBlock.id;
+  message.block = messageBlockID;
 
   if (tag == 0) {
     // Do stuff

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -1,5 +1,14 @@
 import { CrossChainEpochOracleCall } from "../generated/DataEdge/DataEdge";
-import { DataEdge, Message } from "../generated/schema";
+import { Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { DataEdge, Message, MessageBlock } from "../generated/schema";
+import {
+  SET_BLOCK_NUMBERS_FOR_EPOCH,
+  CORRECT_EPOCHS,
+  UPDATE_VERSIONS,
+  REGISTER_NETWORKS,
+  PREAMBLE_BIT_LENGTH,
+  TAG_BIT_LENGTH
+} from "./constants";
 
 export function handleCrossChainEpochOracle(
   call: CrossChainEpochOracleCall
@@ -10,8 +19,47 @@ export function handleCrossChainEpochOracle(
   let txHash = call.transaction.hash.toHexString();
 
   // Save raw message
-  let message = new Message(txHash);
-  message.data = payloadBytes;
-  message.submitter = submitter;
-  message.save();
+  let messageBlock = new MessageBlock(txHash);
+  messageBlock.data = payloadBytes;
+  messageBlock.submitter = submitter;
+  messageBlock.save();
+
+  let tags = getTags(
+    changetype<Bytes>(messageBlock.data.slice(0, PREAMBLE_BIT_LENGTH / 8))
+  );
+  for (let i = 0; i < tags.length; i++) {
+    let message = new Message([txHash, BigInt.fromI32(i).toString()].join("-"));
+    message.type = tags[i];
+    message.block = messageBlock.id;
+    message.save();
+  }
+}
+
+function getTags(preamble: Bytes): Array<String> {
+  let tags = new Array<String>();
+  for (let i = 0; i < PREAMBLE_BIT_LENGTH / TAG_BIT_LENGTH; i++) {
+    tags.push(getTag(preamble, i));
+  }
+  return tags;
+}
+
+function getTag(preamble: Bytes, index: i32): String {
+  return translateI32ToMessageType(
+    (BigInt.fromUnsignedBytes(preamble).toI32() >> (index * TAG_BIT_LENGTH)) &
+      (2 ** TAG_BIT_LENGTH - 1)
+  );
+}
+
+function translateI32ToMessageType(tag: i32): String {
+  let result = "";
+  if (tag == 0) {
+    result = SET_BLOCK_NUMBERS_FOR_EPOCH;
+  } else if (tag == 1) {
+    result = CORRECT_EPOCHS;
+  } else if (tag == 2) {
+    result = UPDATE_VERSIONS;
+  } else if (tag == 3) {
+    result = REGISTER_NETWORKS;
+  }
+  return result;
 }

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -154,7 +154,7 @@ function executeSetBlockNumbersForEpochMessage(
       bytesRead += readAcceleration[1] as i32;
       accelerations.push(BigInt.fromI64(readAcceleration[0]));
     }
-
+    message.accelerations = accelerations
     message.data = changetype<Bytes>(data.slice(0, bytesRead));
     message.save();
   } else {

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -49,23 +49,36 @@ export function handleCrossChainEpochOracle(
       changetype<Bytes>(rawPayloadData.slice(0, PREAMBLE_BIT_LENGTH / 8))
     );
 
+    rawPayloadData = rawPayloadData.slice(PREAMBLE_BIT_LENGTH / 8);
+
     for (let i = 0; i < tags.length; i++) {
-      executeMessage(tags[i], i, globalState, messageBlock.id, rawPayloadData);
+      let bytesRead = executeMessage(
+        tags[i],
+        i,
+        globalState,
+        messageBlock.id,
+        rawPayloadData
+      );
+      rawPayloadData = rawPayloadData.slice(bytesRead);
     }
 
     messageBlock.data = rawPayloadData; // cut it to the amount actually read
     messageBlock.save();
     messageBlockCounter++;
   }
+
+  globalState.save();
 }
 
+// Executes the message and returns the amount of bytes read
 function executeMessage(
   tag: i32,
   index: i32,
   globalState: GlobalState,
   messageBlockID: String,
   data: Bytes
-): void {
+): i32 {
+  let bytesRead = 0;
   // ToDo, parse and actually execute message
   let message = new SetBlockNumbersForEpochMessage(
     [messageBlockID, BigInt.fromI32(index).toString()].join("-")
@@ -73,19 +86,75 @@ function executeMessage(
   message.block = messageBlockID;
 
   if (tag == 0) {
-    // Do stuff
-    message.save();
+    bytesRead = executeSetBlockNumbersForEpochMessage(
+      message,
+      globalState,
+      data
+    );
   } else if (tag == 1) {
-    let coercedMessage = changetype<CorrectEpochsMessage>(message);
-    // Do stuff
-    coercedMessage.save();
+    bytesRead = executeCorrectEpochsMessage(
+      changetype<CorrectEpochsMessage>(message),
+      globalState,
+      data
+    );
   } else if (tag == 2) {
-    let coercedMessage = changetype<UpdateVersionsMessage>(message);
-    // Do stuff
-    coercedMessage.save();
+    bytesRead = executeUpdateVersionsMessage(
+      changetype<UpdateVersionsMessage>(message),
+      globalState,
+      data
+    );
   } else if (tag == 3) {
-    let coercedMessage = changetype<RegisterNetworksMessage>(message);
-    // Do stuff
-    coercedMessage.save();
+    bytesRead = executeRegisterNetworksMessage(
+      changetype<RegisterNetworksMessage>(message),
+      globalState,
+      data
+    );
   }
+
+  return bytesRead;
+}
+
+function executeSetBlockNumbersForEpochMessage(
+  message: SetBlockNumbersForEpochMessage,
+  globalState: GlobalState,
+  data: Bytes
+): i32 {
+  let bytesRead = 0;
+  if (globalState.networkCount != 0) {
+    // To Do
+    message.save();
+  } else {
+    message.save();
+  }
+  return bytesRead;
+}
+
+function executeCorrectEpochsMessage(
+  message: CorrectEpochsMessage,
+  globalState: GlobalState,
+  data: Bytes
+): i32 {
+  let bytesRead = 0;
+  // To Do
+  return bytesRead;
+}
+
+function executeUpdateVersionsMessage(
+  message: UpdateVersionsMessage,
+  globalState: GlobalState,
+  data: Bytes
+): i32 {
+  let bytesRead = 0;
+  // To Do
+  return bytesRead;
+}
+
+function executeRegisterNetworksMessage(
+  message: RegisterNetworksMessage,
+  globalState: GlobalState,
+  data: Bytes
+): i32 {
+  let bytesRead = 0;
+  // To Do
+  return bytesRead;
 }

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -11,7 +11,7 @@ dataSources:
       startBlock: 12052156
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.6
       language: wasm/assemblyscript
       entities:
         - DataEdge

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -8,12 +8,14 @@ dataSources:
     source:
       address: "0xae6ADd894F8a1BcAC10b153dc59Cab1da9656836"
       abi: DataEdge
+      startBlock: 12052156
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
-        - OwnershipTransferred
+        - DataEdge
+        - Message
       abis:
         - name: DataEdge
           file: ./abis/DataEdgeFull.json

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -1,54 +1,193 @@
-import { clearStore, test, assert } from 'matchstick-as/assembly/index'
-import { handleCrossChainEpochOracle } from '../src/mapping'
-import { getGlobalState, getTags, decodePrefixVarIntU64 } from '../src/helpers'
-import { log } from '@graphprotocol/graph-ts'
+import { clearStore, test, assert } from "matchstick-as/assembly/index";
+import { handleCrossChainEpochOracle } from "../src/mapping";
+import { getGlobalState, getTags, decodePrefixVarIntU64 } from "../src/helpers";
+import { log } from "@graphprotocol/graph-ts";
 
 import { CrossChainEpochOracleCall } from "../generated/DataEdge/DataEdge";
 import { Bytes, BigInt } from "@graphprotocol/graph-ts";
 import { DataEdge, MessageBlock, Payload } from "../generated/schema";
 
-test('U64 Decoding', () => {
+test("U64 Decoding 0x2F", () => {
   // 23 -> [47] -> 0x2F
-  // 9000 -> [162, 140] -> 0xA28C
-  // 1455594 -> [84, 175, 177] -> 0x54AFB1
-  // 109771541 -> [88, 177, 175, 104] -> 0x58B1AF68
-  // 24345908991 -> [240, 223, 34, 100, 181] -> 0xF0DF2264B5
-  // 1903269233213 -> [96, 143, 240, 235, 200, 110] -> 0x608FF0EBC86E
-  // 558944227176442 -> [64, 253, 23, 14, 172, 45, 254] -> 0x40FD170EAC2DFE
-  // 72057594037927935 -> [128, 255, 255, 255, 255, 255, 255, 255] -> 0x80FFFFFFFFFFFFFF
 
-  let encoded0x17 = Bytes.fromHexString('0x2F') // 23 u64
-  let encoded0x2328 = Bytes.fromHexString('0xA28C') // 9000 u64
-  let encoded0x1635EA = Bytes.fromHexString('0x54AFB1') // 1455594 u64
-  let encoded0x068AFB15 = Bytes.fromHexString('0x58B1AF68') // 109771541 u64
-  let encoded0x05AB2116FF = Bytes.fromHexString('0xF0DF2264B5') // 24345908991 u64
-  let encoded0x01BB23AFC23D = Bytes.fromHexString('0x608FF0EBC86E') // 1903269233213 u64
-  let encoded0x01FC5B581C2FFA = Bytes.fromHexString('0x40FD170EAC2DFE') // 558944227176442 u64
-  let encoded0xFFFFFFFFFFFFFF = Bytes.fromHexString('0x80FFFFFFFFFFFFFF') // 72057594037927935 u64
+  let encoded = Bytes.fromHexString("0x2F"); // 23 u64
 
-  let decoded0x17 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x17), 0)
-  let decoded0x2328 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x2328), 0)
-  let decoded0x1635EA = decodePrefixVarIntU64(changetype<Bytes>(encoded0x1635EA), 0)
-  let decoded0x068AFB15 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x068AFB15), 0)
-  let decoded0x05AB2116FF = decodePrefixVarIntU64(changetype<Bytes>(encoded0x05AB2116FF), 0)
-  let decoded0x01BB23AFC23D = decodePrefixVarIntU64(changetype<Bytes>(encoded0x01BB23AFC23D), 0)
-  let decoded0x01FC5B581C2FFA = decodePrefixVarIntU64(changetype<Bytes>(encoded0x01FC5B581C2FFA), 0)
-  let decoded0xFFFFFFFFFFFFFF = decodePrefixVarIntU64(changetype<Bytes>(encoded0xFFFFFFFFFFFFFF), 0)
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert.bytesEquals(changetype<Bytes>(Bytes.fromU64(decoded0x17)), Bytes.empty())
-  assert.bigIntEquals(BigInt.fromU64(decoded0x17), BigInt.fromU64(23 as u64))
-  assert.bigIntEquals(BigInt.fromU64(decoded0x2328), BigInt.fromU64(9000 as u64))
-  assert.bigIntEquals(BigInt.fromU64(decoded0x1635EA), BigInt.fromU64(1455594 as u64))
-  assert.bigIntEquals(BigInt.fromU64(decoded0x068AFB15), BigInt.fromU64(109771541 as u64))
-  assert.bigIntEquals(BigInt.fromU64(decoded0x05AB2116FF), BigInt.fromU64(24345908991 as u64))
-  assert.bigIntEquals(BigInt.fromU64(decoded0x01BB23AFC23D), BigInt.fromU64(1903269233213 as u64))
-  assert.bigIntEquals(BigInt.fromU64(decoded0x01FC5B581C2FFA), BigInt.fromU64(558944227176442 as u64))
-  assert.bigIntEquals(BigInt.fromU64(decoded0xFFFFFFFFFFFFFF), BigInt.fromU64(72057594037927935 as u64))
+  // assert values
+  assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(23 as u64));
+
+  // // assert bytes read
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(1 as u64));
 
   // Clear the store in order to start the next test off on a clean slate
-  clearStore()
-})
+  clearStore();
+});
+test("U64 Decoding 0xA28C", () => {
+  // 9000 -> [162, 140] -> 0xA28C
 
-test('I64 Decoding (U64 + ZigZag)', () => {
+  let encoded = Bytes.fromHexString("0xA28C"); // 9000 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(9000 as u64));
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(2 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding 0x54AFB1", () => {
+  // 1455594 -> [84, 175, 177] -> 0x54AFB1
+
+  let encoded = Bytes.fromHexString("0x54AFB1"); // 1455594 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+
+  assert.bigIntEquals(
+    BigInt.fromU64(decoded[0]),
+    BigInt.fromU64(1455594 as u64)
+  );
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(3 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding 0x58B1AF68", () => {
+  // 109771541 -> [88, 177, 175, 104] -> 0x58B1AF68
+
+  let encoded = Bytes.fromHexString("0x58B1AF68"); // 109771541 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+
+  assert.bigIntEquals(
+    BigInt.fromU64(decoded[0]),
+    BigInt.fromU64(109771541 as u64)
+  );
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(4 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding 0xF0DF2264B5", () => {
+  // 24345908991 -> [240, 223, 34, 100, 181] -> 0xF0DF2264B5
+
+  let encoded = Bytes.fromHexString("0xF0DF2264B5"); // 24345908991 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+
+  assert.bigIntEquals(
+    BigInt.fromU64(decoded[0]),
+    BigInt.fromU64(24345908991 as u64)
+  );
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(5 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding 0x608FF0EBC86E", () => {
+  // 1903269233213 -> [96, 143, 240, 235, 200, 110] -> 0x608FF0EBC86E
+
+  let encoded = Bytes.fromHexString("0x608FF0EBC86E"); // 1903269233213 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+
+  assert.bigIntEquals(
+    BigInt.fromU64(decoded[0]),
+    BigInt.fromU64(1903269233213 as u64)
+  );
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(6 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding 0x40FD170EAC2DFE", () => {
+  // 558944227176442 -> [64, 253, 23, 14, 172, 45, 254] -> 0x40FD170EAC2DFE
+
+  let encoded = Bytes.fromHexString("0x40FD170EAC2DFE"); // 558944227176442 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+  assert.bigIntEquals(
+    BigInt.fromU64(decoded[0]),
+    BigInt.fromU64(558944227176442 as u64)
+  );
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(7 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding 0x80FFFFFFFFFFFFFF", () => {
+  // 72057594037927935 -> [128, 255, 255, 255, 255, 255, 255, 255] -> 0x80FFFFFFFFFFFFFF
+
+  let encoded = Bytes.fromHexString("0x80FFFFFFFFFFFFFF"); // 72057594037927935 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+
+  assert.bigIntEquals(
+    BigInt.fromU64(decoded[0]),
+    BigInt.fromU64(72057594037927935 as u64)
+  );
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(8 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding 0x00FFFFFFFFFFFFFFFF", () => {
+  // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
+
+  let encoded = Bytes.fromHexString("0x00FFFFFFFFFFFFFFFF"); // 18446744073709551615 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // assert values
+
+  assert.bigIntEquals(
+    BigInt.fromU64(decoded[0]),
+    BigInt.fromU64(18446744073709551615 as u64)
+  );
+
+  // // assert bytes read
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(9 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+
+test("I64 Decoding (U64 + ZigZag)", () => {
   //...
-})
+});

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -1,21 +1,49 @@
 import { clearStore, test, assert } from 'matchstick-as/assembly/index'
 import { handleCrossChainEpochOracle } from '../src/mapping'
 import { getGlobalState, getTags, decodePrefixVarIntU64 } from '../src/helpers'
+import { log } from '@graphprotocol/graph-ts'
 
 import { CrossChainEpochOracleCall } from "../generated/DataEdge/DataEdge";
 import { Bytes, BigInt } from "@graphprotocol/graph-ts";
 import { DataEdge, MessageBlock, Payload } from "../generated/schema";
 
 test('U64 Decoding', () => {
-  let encoded0x17 = Bytes.fromU64(47) // 23 u64
-  let encoded0x2328 = Bytes.fromU64(41612) // 23 u64
+  // 23 -> [47] -> 0x2F
+  // 9000 -> [162, 140] -> 0xA28C
+  // 1455594 -> [84, 175, 177] -> 0x54AFB1
+  // 109771541 -> [88, 177, 175, 104] -> 0x58B1AF68
+  // 24345908991 -> [240, 223, 34, 100, 181] -> 0xF0DF2264B5
+  // 1903269233213 -> [96, 143, 240, 235, 200, 110] -> 0x608FF0EBC86E
+  // 558944227176442 -> [64, 253, 23, 14, 172, 45, 254] -> 0x40FD170EAC2DFE
+  // 72057594037927935 -> [128, 255, 255, 255, 255, 255, 255, 255] -> 0x80FFFFFFFFFFFFFF
+
+  let encoded0x17 = Bytes.fromHexString('0x2F') // 23 u64
+  let encoded0x2328 = Bytes.fromHexString('0xA28C') // 9000 u64
+  let encoded0x1635EA = Bytes.fromHexString('0x54AFB1') // 1455594 u64
+  let encoded0x068AFB15 = Bytes.fromHexString('0x58B1AF68') // 109771541 u64
+  let encoded0x05AB2116FF = Bytes.fromHexString('0xF0DF2264B5') // 24345908991 u64
+  let encoded0x01BB23AFC23D = Bytes.fromHexString('0x608FF0EBC86E') // 1903269233213 u64
+  let encoded0x01FC5B581C2FFA = Bytes.fromHexString('0x40FD170EAC2DFE') // 558944227176442 u64
+  let encoded0xFFFFFFFFFFFFFF = Bytes.fromHexString('0x80FFFFFFFFFFFFFF') // 72057594037927935 u64
 
   let decoded0x17 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x17), 0)
   let decoded0x2328 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x2328), 0)
+  let decoded0x1635EA = decodePrefixVarIntU64(changetype<Bytes>(encoded0x1635EA), 0)
+  let decoded0x068AFB15 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x068AFB15), 0)
+  let decoded0x05AB2116FF = decodePrefixVarIntU64(changetype<Bytes>(encoded0x05AB2116FF), 0)
+  let decoded0x01BB23AFC23D = decodePrefixVarIntU64(changetype<Bytes>(encoded0x01BB23AFC23D), 0)
+  let decoded0x01FC5B581C2FFA = decodePrefixVarIntU64(changetype<Bytes>(encoded0x01FC5B581C2FFA), 0)
+  let decoded0xFFFFFFFFFFFFFF = decodePrefixVarIntU64(changetype<Bytes>(encoded0xFFFFFFFFFFFFFF), 0)
 
+  // assert.bytesEquals(changetype<Bytes>(Bytes.fromU64(decoded0x17)), Bytes.empty())
   assert.bigIntEquals(BigInt.fromU64(decoded0x17), BigInt.fromU64(23 as u64))
   assert.bigIntEquals(BigInt.fromU64(decoded0x2328), BigInt.fromU64(9000 as u64))
-  assert.bytesEquals(changetype<Bytes>(Bytes.fromU64(decoded0x2328)), Bytes.empty())
+  assert.bigIntEquals(BigInt.fromU64(decoded0x1635EA), BigInt.fromU64(1455594 as u64))
+  assert.bigIntEquals(BigInt.fromU64(decoded0x068AFB15), BigInt.fromU64(109771541 as u64))
+  assert.bigIntEquals(BigInt.fromU64(decoded0x05AB2116FF), BigInt.fromU64(24345908991 as u64))
+  assert.bigIntEquals(BigInt.fromU64(decoded0x01BB23AFC23D), BigInt.fromU64(1903269233213 as u64))
+  assert.bigIntEquals(BigInt.fromU64(decoded0x01FC5B581C2FFA), BigInt.fromU64(558944227176442 as u64))
+  assert.bigIntEquals(BigInt.fromU64(decoded0xFFFFFFFFFFFFFF), BigInt.fromU64(72057594037927935 as u64))
 
   // Clear the store in order to start the next test off on a clean slate
   clearStore()

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -14,10 +14,10 @@ test("U64 Decoding 0x2F", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
   assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(23 as u64));
 
-  // // assert bytes read
+  // Assert length of bytes read
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(1 as u64));
 
   // Clear the store in order to start the next test off on a clean slate
@@ -30,11 +30,11 @@ test("U64 Decoding 0xA28C", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
 
   assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(9000 as u64));
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(2 as u64));
 
@@ -48,14 +48,14 @@ test("U64 Decoding 0x54AFB1", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
 
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(1455594 as u64)
   );
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(3 as u64));
 
@@ -69,14 +69,14 @@ test("U64 Decoding 0x58B1AF68", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
 
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(109771541 as u64)
   );
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(4 as u64));
 
@@ -90,14 +90,14 @@ test("U64 Decoding 0xF0DF2264B5", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
 
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(24345908991 as u64)
   );
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(5 as u64));
 
@@ -111,14 +111,14 @@ test("U64 Decoding 0x608FF0EBC86E", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
 
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(1903269233213 as u64)
   );
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(6 as u64));
 
@@ -132,13 +132,13 @@ test("U64 Decoding 0x40FD170EAC2DFE", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(558944227176442 as u64)
   );
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(7 as u64));
 
@@ -152,14 +152,14 @@ test("U64 Decoding 0x80FFFFFFFFFFFFFF", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
 
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(72057594037927935 as u64)
   );
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(8 as u64));
 
@@ -173,16 +173,70 @@ test("U64 Decoding 0x00FFFFFFFFFFFFFFFF", () => {
 
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
 
-  // assert values
+  // Assert decoded value
 
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(18446744073709551615 as u64)
   );
 
-  // // assert bytes read
+  // Assert length of bytes read
 
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(9 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding InvalidFormat 0x0011", () => {
+  // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
+
+  let encoded = Bytes.fromHexString("0x0011"); // 18446744073709551615 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // Assert decoded value (0 since invalid cases return 0 here)
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(0 as u64));
+
+  // Assert length of bytes read (0 since ivalid cases return 0 here.)
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(0 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding InvalidFormat 0x00", () => {
+  // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
+
+  let encoded = Bytes.fromHexString("0x00"); // 18446744073709551615 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // Assert decoded value (0 since invalid cases return 0 here)
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(0 as u64));
+
+  // Assert length of bytes read (0 since ivalid cases return 0 here.)
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(0 as u64));
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore();
+});
+test("U64 Decoding InvalidFormat 0x00FFFFFFFFFFFFFF (1 byte less than valid)", () => {
+  // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
+
+  let encoded = Bytes.fromHexString("0x00FFFFFFFFFFFFFF"); // 18446744073709551615 u64
+
+  let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
+
+  // Assert decoded value (0 since invalid cases return 0 here)
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(0 as u64));
+
+  // Assert length of bytes read (0 since ivalid cases return 0 here.)
+
+  assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(0 as u64));
 
   // Clear the store in order to start the next test off on a clean slate
   clearStore();

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -154,36 +154,6 @@ test("U64 Decoding InvalidFormat 0x00FFFFFFFFFFFFFF (1 byte less than valid)", (
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(0 as u64));
 });
 
-/*
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn known_values() {
-        let result = ZigZag::encode(0i32);
-        assert_eq!(result, 0);
-
-        let result = ZigZag::encode(-1i32);
-        assert_eq!(result, 1);
-
-        let result = ZigZag::encode(2147483647i32);
-        assert_eq!(result, 4294967294);
-
-        let result = ZigZag::encode(-2147483648i32);
-        assert_eq!(result, 4294967295);
-    }
-
-    #[test]
-    fn all_values() {
-        for i in std::i16::MIN..=std::i16::MAX {
-            let zig = ZigZag::encode(i);
-            let zag = ZigZag::decode(zig);
-            assert_eq!(i, zag);
-        }
-    }
-}
-*/
-
 test("ZigZag Decoding 0", () => {
   // 0 should decode to 0
   let encoded = 0 as u64;

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -4,17 +4,18 @@ import { getGlobalState, getTags, decodePrefixVarIntU64 } from '../src/helpers'
 
 import { CrossChainEpochOracleCall } from "../generated/DataEdge/DataEdge";
 import { Bytes, BigInt } from "@graphprotocol/graph-ts";
-import { DataEdge, Message, MessageBlock, Payload } from "../generated/schema";
+import { DataEdge, MessageBlock, Payload } from "../generated/schema";
 
 test('U64 Decoding', () => {
-  let encoded0x17 = Bytes.fromUnsignedBytes("2f") // 23 u64
-  let encoded0x2328 = Bytes.fromUnsignedBytes("a28c") // 9000 u64
+  let encoded0x17 = Bytes.fromU64(47) // 23 u64
+  let encoded0x2328 = Bytes.fromU64(41612) // 23 u64
 
-  let decoded0x17 = decodePrefixVarIntU64(encoded0x17, 0)
-  let decoded0x2328 = decodePrefixVarIntU64(encoded0x2328, 0)
-  // Assert the state of the store
-  assert.equals(decoded0x17, 23 as u64)
-  assert.equals(decoded0x2328, 9000 as u64)
+  let decoded0x17 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x17), 0)
+  let decoded0x2328 = decodePrefixVarIntU64(changetype<Bytes>(encoded0x2328), 0)
+
+  assert.bigIntEquals(BigInt.fromU64(decoded0x17), BigInt.fromU64(23 as u64))
+  assert.bigIntEquals(BigInt.fromU64(decoded0x2328), BigInt.fromU64(9000 as u64))
+  assert.bytesEquals(changetype<Bytes>(Bytes.fromU64(decoded0x2328)), Bytes.empty())
 
   // Clear the store in order to start the next test off on a clean slate
   clearStore()

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -1,0 +1,25 @@
+import { clearStore, test, assert } from 'matchstick-as/assembly/index'
+import { handleCrossChainEpochOracle } from '../src/mapping'
+import { getGlobalState, getTags, decodePrefixVarIntU64 } from '../src/helpers'
+
+import { CrossChainEpochOracleCall } from "../generated/DataEdge/DataEdge";
+import { Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { DataEdge, Message, MessageBlock, Payload } from "../generated/schema";
+
+test('U64 Decoding', () => {
+  let encoded0x17 = Bytes.fromUnsignedBytes("2f") // 23 u64
+  let encoded0x2328 = Bytes.fromUnsignedBytes("a28c") // 9000 u64
+
+  let decoded0x17 = decodePrefixVarIntU64(encoded0x17, 0)
+  let decoded0x2328 = decodePrefixVarIntU64(encoded0x2328, 0)
+  // Assert the state of the store
+  assert.equals(decoded0x17, 23 as u64)
+  assert.equals(decoded0x2328, 9000 as u64)
+
+  // Clear the store in order to start the next test off on a clean slate
+  clearStore()
+})
+
+test('I64 Decoding (U64 + ZigZag)', () => {
+  //...
+})

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -1,6 +1,12 @@
 import { clearStore, test, assert } from "matchstick-as/assembly/index";
 import { handleCrossChainEpochOracle } from "../src/mapping";
-import { getGlobalState, getTags, decodePrefixVarIntU64 } from "../src/helpers";
+import {
+  getGlobalState,
+  getTags,
+  decodePrefixVarIntU64,
+  decodePrefixVarIntI64,
+  zigZagDecode
+} from "../src/helpers";
 import { log } from "@graphprotocol/graph-ts";
 
 import { CrossChainEpochOracleCall } from "../generated/DataEdge/DataEdge";
@@ -9,237 +15,211 @@ import { DataEdge, MessageBlock, Payload } from "../generated/schema";
 
 test("U64 Decoding 0x2F", () => {
   // 23 -> [47] -> 0x2F
-
   let encoded = Bytes.fromHexString("0x2F"); // 23 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
   assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(23 as u64));
-
   // Assert length of bytes read
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(1 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0xA28C", () => {
   // 9000 -> [162, 140] -> 0xA28C
-
   let encoded = Bytes.fromHexString("0xA28C"); // 9000 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
-
   assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(9000 as u64));
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(2 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0x54AFB1", () => {
   // 1455594 -> [84, 175, 177] -> 0x54AFB1
-
   let encoded = Bytes.fromHexString("0x54AFB1"); // 1455594 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
-
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(1455594 as u64)
   );
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(3 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0x58B1AF68", () => {
   // 109771541 -> [88, 177, 175, 104] -> 0x58B1AF68
-
   let encoded = Bytes.fromHexString("0x58B1AF68"); // 109771541 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
-
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(109771541 as u64)
   );
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(4 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0xF0DF2264B5", () => {
   // 24345908991 -> [240, 223, 34, 100, 181] -> 0xF0DF2264B5
-
   let encoded = Bytes.fromHexString("0xF0DF2264B5"); // 24345908991 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
-
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(24345908991 as u64)
   );
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(5 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0x608FF0EBC86E", () => {
   // 1903269233213 -> [96, 143, 240, 235, 200, 110] -> 0x608FF0EBC86E
-
   let encoded = Bytes.fromHexString("0x608FF0EBC86E"); // 1903269233213 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
-
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(1903269233213 as u64)
   );
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(6 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0x40FD170EAC2DFE", () => {
   // 558944227176442 -> [64, 253, 23, 14, 172, 45, 254] -> 0x40FD170EAC2DFE
-
   let encoded = Bytes.fromHexString("0x40FD170EAC2DFE"); // 558944227176442 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(558944227176442 as u64)
   );
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(7 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0x80FFFFFFFFFFFFFF", () => {
   // 72057594037927935 -> [128, 255, 255, 255, 255, 255, 255, 255] -> 0x80FFFFFFFFFFFFFF
-
   let encoded = Bytes.fromHexString("0x80FFFFFFFFFFFFFF"); // 72057594037927935 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
-
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(72057594037927935 as u64)
   );
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(8 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding 0x00FFFFFFFFFFFFFFFF", () => {
   // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
-
   let encoded = Bytes.fromHexString("0x00FFFFFFFFFFFFFFFF"); // 18446744073709551615 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value
-
   assert.bigIntEquals(
     BigInt.fromU64(decoded[0]),
     BigInt.fromU64(18446744073709551615 as u64)
   );
-
   // Assert length of bytes read
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(9 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding InvalidFormat 0x0011", () => {
   // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
-
   let encoded = Bytes.fromHexString("0x0011"); // 18446744073709551615 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value (0 since invalid cases return 0 here)
-
   assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(0 as u64));
-
   // Assert length of bytes read (0 since ivalid cases return 0 here.)
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(0 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding InvalidFormat 0x00", () => {
   // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
-
   let encoded = Bytes.fromHexString("0x00"); // 18446744073709551615 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value (0 since invalid cases return 0 here)
-
   assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(0 as u64));
-
   // Assert length of bytes read (0 since ivalid cases return 0 here.)
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(0 as u64));
-
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
 });
+
 test("U64 Decoding InvalidFormat 0x00FFFFFFFFFFFFFF (1 byte less than valid)", () => {
   // 18446744073709551615 -> [0, 255, 255, 255, 255, 255, 255, 255, 255] 0x00FFFFFFFFFFFFFFFF
-
   let encoded = Bytes.fromHexString("0x00FFFFFFFFFFFFFF"); // 18446744073709551615 u64
-
   let decoded = decodePrefixVarIntU64(changetype<Bytes>(encoded), 0);
-
   // Assert decoded value (0 since invalid cases return 0 here)
-
   assert.bigIntEquals(BigInt.fromU64(decoded[0]), BigInt.fromU64(0 as u64));
-
   // Assert length of bytes read (0 since ivalid cases return 0 here.)
-
   assert.bigIntEquals(BigInt.fromU64(decoded[1]), BigInt.fromU64(0 as u64));
+});
 
-  // Clear the store in order to start the next test off on a clean slate
-  clearStore();
+/*
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn known_values() {
+        let result = ZigZag::encode(0i32);
+        assert_eq!(result, 0);
+
+        let result = ZigZag::encode(-1i32);
+        assert_eq!(result, 1);
+
+        let result = ZigZag::encode(2147483647i32);
+        assert_eq!(result, 4294967294);
+
+        let result = ZigZag::encode(-2147483648i32);
+        assert_eq!(result, 4294967295);
+    }
+
+    #[test]
+    fn all_values() {
+        for i in std::i16::MIN..=std::i16::MAX {
+            let zig = ZigZag::encode(i);
+            let zag = ZigZag::decode(zig);
+            assert_eq!(i, zag);
+        }
+    }
+}
+*/
+
+test("ZigZag Decoding 0", () => {
+  // 0 should decode to 0
+  let encoded = 0 as u64;
+  let decoded = zigZagDecode(encoded);
+
+  assert.bigIntEquals(BigInt.fromI64(decoded), BigInt.fromI64(0 as i64));
+});
+
+test("ZigZag Decoding 1", () => {
+  // 1 should decode to -1
+  let encoded = 1 as u64;
+  let decoded = zigZagDecode(encoded);
+
+  assert.bigIntEquals(BigInt.fromI64(decoded), BigInt.fromI64(-1 as i64));
+});
+
+test("ZigZag Decoding 4294967294", () => {
+  // 4294967294 should decode to 2147483647
+  let encoded = 4294967294 as u64;
+  let decoded = zigZagDecode(encoded);
+
+  assert.bigIntEquals(
+    BigInt.fromI64(decoded),
+    BigInt.fromI64(2147483647 as i64)
+  );
+});
+
+test("ZigZag Decoding 4294967295", () => {
+  // 4294967295 should decode to
+  let encoded = 4294967295 as u64;
+  let decoded = zigZagDecode(encoded);
+
+  assert.bigIntEquals(
+    BigInt.fromI64(decoded),
+    BigInt.fromI64(-2147483648 as i64)
+  );
 });
 
 test("I64 Decoding (U64 + ZigZag)", () => {

--- a/packages/subgraph/tests/decoding.test.ts
+++ b/packages/subgraph/tests/decoding.test.ts
@@ -182,7 +182,7 @@ test("ZigZag Decoding 4294967294", () => {
 });
 
 test("ZigZag Decoding 4294967295", () => {
-  // 4294967295 should decode to
+  // 4294967295 should decode to -2147483648
   let encoded = 4294967295 as u64;
   let decoded = zigZagDecode(encoded);
 
@@ -190,8 +190,4 @@ test("ZigZag Decoding 4294967295", () => {
     BigInt.fromI64(decoded),
     BigInt.fromI64(-2147483648 as i64)
   );
-});
-
-test("I64 Decoding (U64 + ZigZag)", () => {
-  //...
 });

--- a/packages/subgraph/yarn.lock
+++ b/packages/subgraph/yarn.lock
@@ -24,9 +24,9 @@
     js-tokens "^4.0.0"
 
 "@babel/runtime@^7.9.2":
-  version "7.17.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
-  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.7.tgz#a5f3328dc41ff39d803f311cfe17703418cf9825"
+  integrity sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -45,166 +45,166 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
-"@ethersproject/abstract-provider@^5.5.0":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
-  integrity sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==
+"@ethersproject/abstract-provider@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
+  integrity sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==
   dependencies:
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/networks" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
-    "@ethersproject/transactions" "^5.5.0"
-    "@ethersproject/web" "^5.5.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
 
-"@ethersproject/abstract-signer@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
-  integrity sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==
+"@ethersproject/abstract-signer@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
+  integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==
   dependencies:
-    "@ethersproject/abstract-provider" "^5.5.0"
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
 
-"@ethersproject/address@^5.0.4", "@ethersproject/address@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
-  integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
+"@ethersproject/address@^5.0.4", "@ethersproject/address@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.0.tgz#13c49836d73e7885fc148ad633afad729da25012"
+  integrity sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==
   dependencies:
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/keccak256" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
 
-"@ethersproject/base64@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
-  integrity sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==
+"@ethersproject/base64@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.0.tgz#a12c4da2a6fb86d88563216b0282308fc15907c9"
+  integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/bytes" "^5.6.0"
 
-"@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.5.0.tgz#875b143f04a216f4f8b96245bde942d42d279527"
-  integrity sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==
+"@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.0.tgz#116c81b075c57fa765a8f3822648cf718a8a0e26"
+  integrity sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
     bn.js "^4.11.9"
 
-"@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
-  integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
+"@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.0.tgz#81652f2a0e04533575befadce555213c11d8aa20"
+  integrity sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==
   dependencies:
-    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
-  integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
+"@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.0.tgz#55e3eb0918584d3acc0688e9958b0cedef297088"
+  integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
   dependencies:
-    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bignumber" "^5.6.0"
 
 "@ethersproject/hash@^5.0.4":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
-  integrity sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
+  integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==
   dependencies:
-    "@ethersproject/abstract-signer" "^5.5.0"
-    "@ethersproject/address" "^5.5.0"
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/keccak256" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
-    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
-"@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
-  integrity sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==
+"@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.0.tgz#fea4bb47dbf8f131c2e1774a1cecbfeb9d606459"
+  integrity sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/bytes" "^5.6.0"
     js-sha3 "0.8.0"
 
-"@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
-  integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+"@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
 
-"@ethersproject/networks@^5.5.0":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.2.tgz#784c8b1283cd2a931114ab428dae1bd00c07630b"
-  integrity sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==
+"@ethersproject/networks@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.0.tgz#486d03fff29b4b6b5414d47a232ded09fe10de5e"
+  integrity sha512-DaVzgyThzHgSDLuURhvkp4oviGoGe9iTZW4jMEORHDRCgSZ9K9THGFKqL+qGXqPAYLEgZTf5z2w56mRrPR1MjQ==
   dependencies:
-    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
-  integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
+"@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
+  integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
   dependencies:
-    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/rlp@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
-  integrity sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==
+"@ethersproject/rlp@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.0.tgz#55a7be01c6f5e64d6e6e7edb6061aa120962a717"
+  integrity sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/signing-key@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"
-  integrity sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==
+"@ethersproject/signing-key@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.0.tgz#4f02e3fb09e22b71e2e1d6dc4bcb5dafa69ce042"
+  integrity sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
     bn.js "^4.11.9"
     elliptic "6.5.4"
     hash.js "1.1.7"
 
-"@ethersproject/strings@^5.0.4", "@ethersproject/strings@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.5.0.tgz#e6784d00ec6c57710755699003bc747e98c5d549"
-  integrity sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==
+"@ethersproject/strings@^5.0.4", "@ethersproject/strings@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.0.tgz#9891b26709153d996bf1303d39a7f4bc047878fd"
+  integrity sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/constants" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/transactions@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.5.0.tgz#7e9bf72e97bcdf69db34fe0d59e2f4203c7a2908"
-  integrity sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==
+"@ethersproject/transactions@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.6.0.tgz#4b594d73a868ef6e1529a2f8f94a785e6791ae4e"
+  integrity sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==
   dependencies:
-    "@ethersproject/address" "^5.5.0"
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/constants" "^5.5.0"
-    "@ethersproject/keccak256" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
-    "@ethersproject/rlp" "^5.5.0"
-    "@ethersproject/signing-key" "^5.5.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
 
-"@ethersproject/web@^5.5.0":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.1.tgz#cfcc4a074a6936c657878ac58917a61341681316"
-  integrity sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==
+"@ethersproject/web@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.0.tgz#4bf8b3cbc17055027e1a5dd3c357e37474eaaeb8"
+  integrity sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==
   dependencies:
-    "@ethersproject/base64" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
-    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/base64" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@graphprotocol/graph-cli@0.27.0":
   version "0.27.0"
@@ -282,9 +282,9 @@
     "@types/node" "*"
 
 "@types/lodash@^4.14.139":
-  version "4.14.179"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
-  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
+  version "4.14.180"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
+  integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==
 
 "@types/node@*":
   version "17.0.21"
@@ -297,9 +297,9 @@
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/node@^12.7.7":
-  version "12.20.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.46.tgz#7e49dee4c54fd19584e6a9e0da5f3dc2e9136bc7"
-  integrity sha512-cPjLXj8d6anFPzFvOPxS3fvly3Shm5nTfl6g8X5smexixbuGUf7hfr21J5tX9JW+UPStp/5P5R8qrKL5IyVJ+A==
+  version "12.20.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
+  integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==
 
 "@types/node@^8.0.0":
   version "8.10.66"
@@ -985,9 +985,9 @@ debug@^3.2.6:
     ms "^2.1.1"
 
 debug@^4.1.0:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -2155,17 +2155,17 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-mime-db@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
-  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.34"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
-  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
-    mime-db "1.51.0"
+    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"

--- a/packages/subgraph/yarn.lock
+++ b/packages/subgraph/yarn.lock
@@ -237,7 +237,7 @@
     which "2.0.2"
     yaml "1.9.2"
 
-"@graphprotocol/graph-ts@0.24.1":
+"@graphprotocol/graph-ts@0.24.1", "@graphprotocol/graph-ts@^0.24.1":
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.24.1.tgz#50961b52b5383f9c5cf5e6e23fa039f24e729ddf"
   integrity sha512-2vU4m5ZPQIqMlMce/z5vmOtGHRlRmcRhMfemS3NIwxCSxSBGVnX2zb7QBTzzdQKGwsAZdbz6V0okkOtvohELfQ==
@@ -460,6 +460,15 @@ assemblyscript@0.19.10:
     binaryen "101.0.0-nightly.20210723"
     long "^4.0.0"
 
+assemblyscript@^0.19.20:
+  version "0.19.23"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.19.23.tgz#16ece69f7f302161e2e736a0f6a474e6db72134c"
+  integrity sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==
+  dependencies:
+    binaryen "102.0.0-nightly.20211028"
+    long "^5.2.0"
+    source-map-support "^0.5.20"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -546,6 +555,11 @@ binaryen@101.0.0-nightly.20210723:
   version "101.0.0-nightly.20210723"
   resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-101.0.0-nightly.20210723.tgz#b6bb7f3501341727681a03866c0856500eec3740"
   integrity sha512-eioJNqhHlkguVSbblHOtLqlhtC882SOEPKmNFZaDuz1hzQjolxZ+eu3/kaS10n3sGPONsIZsO7R9fR00UyhEUA==
+
+binaryen@102.0.0-nightly.20211028:
+  version "102.0.0-nightly.20211028"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-102.0.0-nightly.20211028.tgz#8f1efb0920afd34509e342e37f84313ec936afb2"
+  integrity sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w==
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -1390,9 +1404,9 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"
@@ -2108,6 +2122,11 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+long@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
+  integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
+
 looper@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/looper/-/looper-3.0.0.tgz#2efa54c3b1cbaba9b94aee2e5914b0be57fbb749"
@@ -2140,6 +2159,15 @@ mafmt@^7.0.0:
   integrity sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==
   dependencies:
     multiaddr "^7.3.0"
+
+matchstick-as@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.4.1.tgz#005a220fda442eacfceef2655b106eed6c2fbc68"
+  integrity sha512-AylFWX+hLRThWY8BMxN0x9bv/ro1ea1qysQ12NvD65g0iKYa8c/TRR0HFtddNEy9Ev5ixzWMzxcl8KVx7YKOVQ==
+  dependencies:
+    "@graphprotocol/graph-ts" "^0.24.1"
+    assemblyscript "^0.19.20"
+    wabt "1.0.24"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -2948,6 +2976,19 @@ signed-varint@^2.0.1:
   dependencies:
     varint "~5.0.0"
 
+source-map-support@^0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 split-ca@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split-ca/-/split-ca-1.0.1.tgz#6c83aff3692fa61256e0cd197e05e9de157691a6"
@@ -3271,6 +3312,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+wabt@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/wabt/-/wabt-1.0.24.tgz#c02e0b5b4503b94feaf4a30a426ef01c1bea7c6c"
+  integrity sha512-8l7sIOd3i5GWfTWciPL0+ff/FK/deVK2Q6FN+MPz4vfUcD78i2M/49XJTwF6aml91uIiuXJEsLKWMB2cw/mtKg==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I'm proposing we should update the `block-oracle` branch to track the latest state of subgraph-related things. This allows us to query payloads, calls, message types, and networks.