### PR TITLE
Grab the latest nonce from protocol chain JSON RPC

### DIFF
--- a/packages/oracle/src/emitter.rs
+++ b/packages/oracle/src/emitter.rs
@@ -16,6 +16,7 @@ pub struct Emitter<'a> {
     client: &'a ProtocolChain,
     contract_address: H160,
     owner_private_key: SecretKey,
+    owner_address: H160,
 }
 
 impl<'a> Emitter<'a> {
@@ -24,14 +25,16 @@ impl<'a> Emitter<'a> {
             client: &config.protocol_chain,
             contract_address: config.contract_address,
             owner_private_key: config.owner_private_key,
+            owner_address: config.owner_address,
         }
     }
 
     pub async fn submit_oracle_messages(
         &mut self,
-        nonce: u64,
         calldata: Vec<u8>,
     ) -> Result<web3::types::TransactionReceipt, EmitterError> {
+        let nonce = self.client.get_latest_nonce(self.owner_address).await? + 1;
+
         let tx_object = TransactionParameters {
             to: Some(self.contract_address),
             value: U256::zero(),
@@ -43,9 +46,9 @@ impl<'a> Emitter<'a> {
             .client
             .sign_transaction(tx_object, &self.owner_private_key)
             .await?;
-        debug!(hash = ?signed.transaction_hash, nonce = nonce, "Signed transaction.");
+        debug!(hash = ?signed.transaction_hash, nonce = %nonce, "Signed transaction.");
         let receipt = self.client.send_transaction(signed).await?;
-        info!(hash = ?receipt.transaction_hash, nonce = nonce, "Sent transaction.");
+        info!(hash = ?receipt.transaction_hash, nonce = %nonce, "Sent transaction.");
         Ok(receipt)
     }
 }

--- a/packages/oracle/src/protocol_chain.rs
+++ b/packages/oracle/src/protocol_chain.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use url::Url;
 use web3::{
     types::{
-        BlockNumber, SignedTransaction, Trace, TraceFilter, TraceFilterBuilder,
-        TransactionParameters, TransactionReceipt, H160, U64,
+        BlockNumber, SignedTransaction, Trace, TraceFilterBuilder,
+        TransactionParameters, TransactionReceipt, H160, U64, U256,
     },
     Web3,
 };
@@ -60,6 +60,10 @@ impl ProtocolChain {
 
     pub async fn get_latest_block(&self) -> Result<U64, web3::Error> {
         self.web3.eth().block_number().await
+    }
+
+    pub async fn get_latest_nonce(&self, address: H160) -> Result<U256, web3::Error> {
+        self.web3.eth().transaction_count(address, None).await
     }
 
     /// Get a reference to the protocol chain client's chain id.


### PR DESCRIPTION
I cherry-picked https://github.com/edgeandnode/block-oracle/pull/39/files#diff-e2a084e86fa22b75e477833379a5f9b68b4bc0d7ca82615f4ced3b04355269d3=, so we can enjoy the nonce fix without breaking things while we migrate away from the database.