### PR TITLE
Remove trace filtering 

### DIFF
--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -303,7 +303,7 @@ mod freshness {
     use crate::protocol_chain::ProtocolChain;
     use thiserror::Error;
     use tracing::{debug, error, trace};
-    use web3::types::{Action, H160, U64};
+    use web3::types::{H160, U64};
 
     #[derive(Debug, Error)]
     enum FreshnessCheckEror {

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -358,8 +358,8 @@ mod freshness {
             return Ok(false);
         }
         // Scan the blocks in betwenn for transactions from the Owner to the Data Edge contract
-        let traces = protocol_chain
-            .traces_in_block_range(
+        let calls = protocol_chain
+            .calls_in_block_range(
                 subgraph_latest_block,
                 current_block,
                 owner_address,
@@ -367,19 +367,7 @@ mod freshness {
             )
             .await?;
 
-        if traces
-            .iter()
-            .any(|trace| matches!(trace.action, Action::Call(_)))
-        {
-            debug!(
-                %subgraph_latest_block,
-                %current_block,
-                "Epoch Subgraph is not fresh. \
-                 Found {} calls between the last synced block and the protocol chain's head",
-                traces.len()
-            );
-            Ok(false)
-        } else {
+        if calls.is_empty() {
             trace!(
                 %subgraph_latest_block,
                 %current_block,
@@ -387,6 +375,15 @@ mod freshness {
                  Found no calls between last synced block and the protocol chain's head",
             );
             Ok(true)
+        } else {
+            debug!(
+                %subgraph_latest_block,
+                %current_block,
+                "Epoch Subgraph is not fresh. \
+                 Found {} calls between the last synced block and the protocol chain's head",
+                calls.len()
+            );
+            Ok(false)
         }
     }
 }

--- a/crates/oracle/src/protocol_chain.rs
+++ b/crates/oracle/src/protocol_chain.rs
@@ -1,9 +1,14 @@
 use crate::{store::Caip2ChainId, transport::JsonRpcExponentialBackoff};
+use futures::future::try_join_all;
 use secp256k1::SecretKey;
 use std::time::Duration;
+use tracing::error;
 use url::Url;
 use web3::{
-    types::{SignedTransaction, TransactionParameters, TransactionReceipt, H160, U256, U64},
+    types::{
+        SignedTransaction, Transaction, TransactionParameters, TransactionReceipt, H160, H256,
+        U256, U64,
+    },
     Web3,
 };
 
@@ -68,13 +73,60 @@ impl ProtocolChain {
         &self.chain_id
     }
 
+    /// Scans a block range for relevant transactions.
+    ///
+    /// Returns a vector of the filtered transactions.
     pub async fn calls_in_block_range(
         &self,
         from_block: U64,
         to_block: U64,
         from_address: H160,
         to_address: H160,
-    ) -> Result<Vec<()>, web3::Error> {
-        todo!()
+    ) -> Result<Vec<Transaction>, web3::Error> {
+        let block_range: Vec<_> = (from_block.as_u64()..=to_block.as_u64()).collect();
+        // Prepare all async calls for fetching blocks in range
+        let block_futures: Vec<_> = block_range
+            .iter()
+            .map(|block_number| {
+                let block_number: U64 = (*block_number).into();
+                self.web3.eth().block(block_number.into())
+            })
+            .collect();
+        // Searching is fallible, so we get a vector of options
+        let optional_blocks = try_join_all(block_futures).await?;
+        // This will store all transaction hashes found within the fetched blocks
+        let mut transaction_hashes: Vec<H256> = Vec::new();
+        // Extract the transaction hashes from the the received blocks
+        for (opt, block_number) in optional_blocks.into_iter().zip(block_range) {
+            if let Some(block) = opt {
+                for transaction_hash in block.transactions.into_iter() {
+                    transaction_hashes.push(transaction_hash)
+                }
+            } else {
+                error!(%block_number, "Failed to fetch block by number");
+            }
+        }
+        // Prepare the async calls for fetching the full transaction objects
+        let transaction_futures: Vec<_> = transaction_hashes
+            .iter()
+            .map(|transaction_hash| self.web3.eth().transaction((*transaction_hash).into()))
+            .collect();
+        // Again, searching is fallible, meaning we get back a vector of optional values
+        let optional_transactions = try_join_all(transaction_futures).await?;
+        // This will hold the filtered transactions that will be returned by thins function
+        let mut filtered_transactions: Vec<Transaction> = Vec::new();
+        // Iterate over all received transactions and filter the ones we are interested in
+        for (opt, transaction_hash) in optional_transactions.into_iter().zip(transaction_hashes) {
+            if let Some(transaction) = opt {
+                if matches!((transaction.from, transaction.to), (Some(a), Some(b)) if a == from_address && b == to_address)
+                {
+                    filtered_transactions.push(transaction)
+                }
+            } else {
+                error!(%transaction_hash, "Failed to fetch transaction by hash");
+            }
+        }
+
+        Ok(filtered_transactions)
     }
 }

--- a/crates/oracle/src/protocol_chain.rs
+++ b/crates/oracle/src/protocol_chain.rs
@@ -3,10 +3,7 @@ use secp256k1::SecretKey;
 use std::time::Duration;
 use url::Url;
 use web3::{
-    types::{
-        BlockNumber, SignedTransaction, Trace, TraceFilterBuilder, TransactionParameters,
-        TransactionReceipt, H160, U256, U64,
-    },
+    types::{SignedTransaction, TransactionParameters, TransactionReceipt, H160, U256, U64},
     Web3,
 };
 
@@ -71,20 +68,13 @@ impl ProtocolChain {
         &self.chain_id
     }
 
-    pub async fn traces_in_block_range(
+    pub async fn calls_in_block_range(
         &self,
         from_block: U64,
         to_block: U64,
         from_address: H160,
         to_address: H160,
-    ) -> Result<Vec<Trace>, web3::Error> {
-        let trace_filter = TraceFilterBuilder::default()
-            .from_block(BlockNumber::Number(from_block))
-            .to_block(BlockNumber::Number(to_block))
-            .from_address(vec![from_address])
-            .to_address(vec![to_address])
-            .count(1)
-            .build();
-        self.web3.trace().filter(trace_filter).await
+    ) -> Result<Vec<()>, web3::Error> {
+        todo!()
     }
 }


### PR DESCRIPTION
This removes the dependency on the `trace_filter` JSON RPC call by refactoring the old code to directly fetch and scan blocks and their transactions.