### PR TITLE
Add a data edge contract that emits an event with the calldata

### DIFF
--- a/packages/contracts/contracts/EventfulDataEdge.sol
+++ b/packages/contracts/contracts/EventfulDataEdge.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.12;
+
+/// @title Data Edge contract is only used to store on-chain data, it does not
+///        perform execution. On-chain client services can read the data
+///        and decode the payload for different purposes.
+///        NOTE: This version emits an event with the calldata.
+contract EventfulDataEdge {
+    event Log(bytes data);
+
+    /// @dev Fallback function, accepts any payload
+    fallback() external {
+        emit Log(msg.data);
+    }
+}

--- a/packages/contracts/test/eventful-dataedge.test.ts
+++ b/packages/contracts/test/eventful-dataedge.test.ts
@@ -1,0 +1,62 @@
+import { ethers } from 'hardhat'
+import '@nomiclabs/hardhat-ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+
+import { EventfulDataEdge__factory, EventfulDataEdge } from '../build/types'
+import { expect } from 'chai'
+
+const { getContractFactory, getSigners } = ethers
+const { id, hexConcat, randomBytes, hexlify, defaultAbiCoder } = ethers.utils
+
+describe('EventfulDataEdge', () => {
+  let edge: EventfulDataEdge
+  let me: SignerWithAddress
+
+  beforeEach(async () => {
+    ;[me] = await getSigners()
+
+    const factory = (await getContractFactory('EventfulDataEdge', me)) as EventfulDataEdge__factory
+    edge = await factory.deploy()
+    await edge.deployed()
+  })
+
+  describe('submit data', async () => {
+    it('post any arbitrary data as selector', async () => {
+      // virtual function call
+      const txRequest = {
+        data: '0x123123',
+        to: edge.address,
+      }
+      // send transaction
+      const tx = await me.sendTransaction(txRequest)
+      const rx = await tx.wait()
+      // transaction must work - it just stores data
+      expect(rx.status).eq(1)
+      // emit log event
+      const event = edge.interface.parseLog(rx.logs[0]).args
+      expect(event.data).eq(txRequest.data)
+    })
+
+    it('post long calldata', async () => {
+      // virtual function call
+      const selector = id('setEpochBlocksPayload(bytes)').slice(0, 10)
+      // calldata payload
+      const messageBlocks = hexlify(randomBytes(1000))
+      const txCalldata = defaultAbiCoder.encode(['bytes'], [messageBlocks]) // we abi encode to allow the subgraph to decode it properly
+      const txData = hexConcat([selector, txCalldata])
+      // craft full transaction
+      const txRequest = {
+        data: txData,
+        to: edge.address,
+      }
+      // send transaction
+      const tx = await me.sendTransaction(txRequest)
+      const rx = await tx.wait()
+      // transaction must work - it just stores data
+      expect(rx.status).eq(1)
+      // emit log event
+      const event = edge.interface.parseLog(rx.logs[0]).args
+      expect(event.data).eq(txRequest.data)
+    })
+  })
+})


### PR DESCRIPTION
### Motivation

For testing purposes we want a DataEdge contract that we can use with no need for traces. It's helpful for local environments using Hardhat that doesn't support traces (required by the call handlers).

### Changes

- Adds an EventfulDataEdge contract