### PR TITLE
local-environment: Make block-oracle wait for graph-node

### DIFF
--- a/.local/.overmind.env
+++ b/.local/.overmind.env
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 OVERMIND_CAN_DIE=deploy-contract,deploy-subgraph
 
+export DEPLOYMENT_HASH=QmbtSBPVexNQhDcwrFbeUZCJrSZmRwT8JQaByvKNA3fR9S
+
 export HARDHAT_JRPC_PORT=8545
 export IPFS_PORT=5001
 

--- a/.local/block-oracle.sh
+++ b/.local/block-oracle.sh
@@ -3,9 +3,12 @@ set -eu
 
 . ./prelude.sh
 
-await_contract
-
 cd ../crates/oracle/
+
+cargo build
+
+await_contract
+await_subgraph
 
 cargo run -- \
 	--config-file=config/dev/config.toml \

--- a/.local/prelude.sh
+++ b/.local/prelude.sh
@@ -70,3 +70,27 @@ await_contract() {
 	done
 	set -e
 }
+
+subgraph_is_ready() {
+	curl --silent --fail "http://localhost:${GRAPH_NODE_GRAPHQL_PORT}/subgraphs/id/${DEPLOYMENT_HASH}" \
+		-X POST \
+		-d '{"query": ""}' \
+		-H 'Content-Type: application/json; charset=utf-8' \
+		-o /dev/null
+}
+
+await_subgraph() {
+	timeout="${1:-2}"
+	set +e
+	while true; do
+		subgraph_is_ready
+		exit_code=$?
+		if [ $exit_code -eq 7 ]; then
+			echo "Waiting for graph-node to go live"
+		else
+			break
+		fi
+		sleep "$timeout"
+	done
+	set -e
+}


### PR DESCRIPTION
We will have to update the `DEPLOYMENT_HASH` env every time the subgraph code changes, but I think this is already the case with Oracle's config file.