### PR TITLE
Remove unused dependencies

### DIFF
--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-never = "0.1.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 zigzag = "0.1.0"
 

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -4,12 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-actix-web = "4"
-async-trait = "0.1.52"
 backoff = { version = "0.4.0", features = [ "tokio" ] }
 clap = { version = "3.0.0", features = ["derive"] }
 ctrlc = "3.2.1"
-envconfig = "0.10.0"
 epoch-encoding = { path = "../encoding" }
 futures = "0.3.21"
 jsonrpc-core = "18.0.0"


### PR DESCRIPTION
We've got the following report from [`cargo udeps`](https://crates.io/crates/cargo-udeps):
```unused dependencies:
block-oracle v0.1.0
└─── dependencies
     ├─── "actix-web"
     ├─── "async-trait"
     └─── "envconfig"
epoch-encoding v0.1.0
└─── dependencies
     └─── "never"
```

We should make sure that those dependencies are really not used before removing them.

@neysofu, I thought we were using `envconfig`, but I might be mistaken.