### PR TITLE
MVP: query the subgraph

### DIFF
--- a/.local/.overmind.env
+++ b/.local/.overmind.env
@@ -2,6 +2,7 @@
 OVERMIND_CAN_DIE=deploy-contract,deploy-subgraph
 
 export DEPLOYMENT_HASH=QmbtSBPVexNQhDcwrFbeUZCJrSZmRwT8JQaByvKNA3fR9S
+export RUST_BACKTRACE=1
 
 export HARDHAT_JRPC_PORT=8545
 export IPFS_PORT=5001

--- a/.local/block-oracle.sh
+++ b/.local/block-oracle.sh
@@ -13,4 +13,5 @@ await_subgraph
 cargo run -- \
 	--config-file=config/dev/config.toml \
 	--database-url=:memory: \
+	--subgraph-url="http://127.0.0.1:${GRAPH_NODE_GRAPHQL_PORT}/subgraphs/name/edgeandnode/block-oracle" \
 	--owner-private-key=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["crates/encoding", "crates/oracle"]
+members = ["crates/*"]

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -63,6 +63,19 @@ impl CompressionEngine {
                 }
             }
             Message::RegisterNetworks { remove, add } => {
+                // TODO: removals.
+                for added in add {
+                    self.network_data.push((
+                        added.clone(),
+                        Network {
+                            block_delta: 0,
+                            block_number: 0,
+                        },
+                    ));
+                    self.network_ids_by_name
+                        .insert(added.clone(), self.network_data.len() as NetworkId - 1);
+                }
+
                 self.compressed.push(CompressedMessage::RegisterNetworks {
                     remove: remove.clone(),
                     add: add.clone(),

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -5,14 +5,16 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4"
-backoff = { version = "0.4.0", features = [ "tokio" ] }
+backoff = { version = "0.4.0", features = ["tokio"] }
 clap = { version = "3.0.0", features = ["derive"] }
 ctrlc = "3.2.1"
 epoch-encoding = { path = "../encoding" }
 futures = "0.3.21"
 jsonrpc-core = "18.0.0"
+graphql_client = "0.10.0"
 lazy_static = "1"
 prometheus = "0.13.0"
+reqwest = "0.11.10"
 secp256k1 = "0.21"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_with = "1.1.12"

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -37,6 +37,7 @@ pub struct Config {
     pub owner_private_key: SecretKey,
     pub contract_address: H160,
     pub database_url: String,
+    pub subgraph_url: String,
     pub epoch_duration: u64,
     pub protocol_chain_polling_interval: Duration,
     pub indexed_chains: Arc<Vec<IndexedChain>>,
@@ -58,6 +59,7 @@ impl Config {
             owner_private_key: SecretKey::from_str(clap.owner_private_key.as_str()).unwrap(),
             contract_address: config_file.contract_address.parse().unwrap(),
             database_url: clap.database_url,
+            subgraph_url: clap.subgraph_url,
             epoch_duration: config_file.epoch_duration,
             protocol_chain_polling_interval: Duration::from_secs(
                 config_file.protocol_chain_polling_interval_in_seconds,
@@ -96,6 +98,9 @@ struct Clap {
     /// The Ethereum address of the Data Edge smart contract.
     #[clap(long)]
     database_url: String,
+    /// The subgraph endpoint.
+    #[clap(long)]
+    subgraph_url: String,
     /// The filepath of the TOML JSON-RPC configuration file.
     #[clap(long, default_value = "config.toml", parse(from_os_str))]
     config_file: PathBuf,

--- a/crates/oracle/src/graphql/query.graphql
+++ b/crates/oracle/src/graphql/query.graphql
@@ -1,0 +1,18 @@
+query SubgraphState {
+  networks {
+    id
+    removedAt {
+      id
+    }
+    blockNumbers {
+      id
+      acceleration
+      delta
+      blockNumber
+      epoch
+    }
+    nextArrayElement
+    arrayIndex
+    state
+  }
+}

--- a/crates/oracle/src/graphql/schema.graphql
+++ b/crates/oracle/src/graphql/schema.graphql
@@ -1,0 +1,103 @@
+scalar ID
+scalar Bytes
+scalar BigInt
+
+type Query {
+  networks: [Network!]!
+}
+
+type DataEdge {
+  id: ID!
+  owner: Bytes!
+}
+
+type Payload {
+  id: ID!
+  data: Bytes!
+  submitter: String!
+  messageBlocks: [MessageBlock!]!
+}
+
+type MessageBlock {
+  id: ID!
+  data: Bytes!
+  payload: Payload!
+  messages: [Message!]!
+}
+
+interface Message {
+  id: ID!
+  block: MessageBlock!
+  "data is optional since it might be an empty message"
+  data: Bytes
+}
+
+type SetBlockNumbersForEpochMessage implements Message {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes
+  merkleRoot: Bytes
+  accelerations: [BigInt!]
+  count: BigInt
+}
+
+type CorrectEpochsMessage implements Message {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes
+}
+
+type UpdateVersionsMessage implements Message {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes
+}
+
+type RegisterNetworksMessage implements Message {
+  id: ID!
+  block: MessageBlock!
+  data: Bytes
+  removeCount: BigInt!
+  addCount: BigInt!
+  networksRemoved: [Network!]!
+  networksAdded: [Network!]!
+}
+
+type Network {
+  id: ID! # chainID now
+  #chainID: String!
+  addedAt: RegisterNetworksMessage!
+  removedAt: RegisterNetworksMessage
+  blockNumbers: [NetworkEpochBlockNumber!]!
+  # Linked-list implementation for pop-and-swap
+  "Next element on the linked-list implementation for networks. Used for list recreation"
+  nextArrayElement: Network
+  "Index number on the linked list"
+  arrayIndex: Int
+  # Link to global state to be able to recreate the list on query time for the GlobalState entity
+  state: GlobalState
+}
+
+type GlobalState {
+  id: ID!
+  networkCount: Int!
+  activeNetworkCount: Int!
+  networkArrayHead: Network
+  latestValidEpoch: Epoch
+  networks: [Network!]!
+}
+
+type Epoch {
+  id: ID!
+  epochNumber: BigInt!
+  blockNumbers: [NetworkEpochBlockNumber!]!
+}
+
+type NetworkEpochBlockNumber {
+  id: ID!
+  acceleration: BigInt!
+  delta: BigInt!
+  blockNumber: BigInt!
+  network: Network!
+  epoch: Epoch!
+}

--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -1,0 +1,168 @@
+use graphql_client::{GraphQLQuery, Response};
+use serde::{de, Deserialize, Deserializer};
+use std::fmt;
+
+pub type Id = String;
+pub type BigInt = u128;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/schema.graphql",
+    query_path = "src/graphql/query.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug",
+    deprecated = "warn"
+)]
+pub struct SubgraphState;
+
+pub async fn query(url: &str) -> reqwest::Result<subgraph_state::ResponseData> {
+    // TODO: authentication token.
+    let client = reqwest::Client::builder()
+        .user_agent("block-oracle")
+        .build()
+        .unwrap();
+    let request_body = SubgraphState::build_query(subgraph_state::Variables);
+    let request = client.post(url).json(&request_body);
+    let response = request.send().await?;
+    let response_body: Response<subgraph_state::ResponseData> = response.json().await?;
+
+    println!("{:?}", response_body.errors);
+
+    Ok(response_body.data.unwrap())
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataEdge {
+    id: Id,
+    #[serde(deserialize_with = "deserialize_hex_string")]
+    owner: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Payload {
+    id: Id,
+    #[serde(deserialize_with = "deserialize_hex_string")]
+    data: Vec<u8>,
+    submitter: String,
+    message_blocks: Vec<MessageBlock>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageBlock {
+    id: Id,
+    #[serde(deserialize_with = "deserialize_hex_string")]
+    data: Vec<u8>,
+    paylaod: Payload,
+    messages: Vec<Message>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageData {
+    id: Id,
+    block: MessageBlock,
+    data: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Message {
+    data: MessageData,
+    kind: MessageKind,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MessageKind {
+    SetBlockNumbersForEpochMessage(SetBlockNumbersForEpochMessage),
+    CorrectEpochsMessage(CorrectEpochsMessage),
+    UpdateVersionsMessage(UpdateVersionsMessage),
+    RegisterNetworksMessage(RegisterNetworksMessage),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetBlockNumbersForEpochMessage {
+    merkle_root: Option<Vec<u8>>,
+    accelerations: Option<Vec<u128>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CorrectEpochsMessage {}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateVersionsMessage {}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterNetworksMessage {
+    remove_count: u64,
+    add_count: u64,
+    networks_removed: Vec<Network>,
+    networks_added: Vec<Network>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Network {
+    id: Id,
+    chain_id: String,
+    block_numbers: Vec<NetworkEpochBlockNumber>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkEpochBlockNumber {
+    id: Id,
+    acceleration: i128,
+    delta: i128,
+    block_number: u128,
+    network: Network,
+    epoch: Epoch,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Epoch {
+    id: Id,
+    epoch_number: u128,
+    block_numbers: Vec<NetworkEpochBlockNumber>,
+}
+
+fn deserialize_hex_string<'de, D>(de: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct HexStringVisitor;
+
+    impl<'de> de::Visitor<'de> for HexStringVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a hexadecimal string (e.g. 0x1337)")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if let Some(s) = v.strip_prefix("0x") {
+                hex::decode(s).map_err(de::Error::custom)
+            } else {
+                Err(de::Error::custom("not a hexadecimal string"))
+            }
+        }
+    }
+
+    de.deserialize_string(HexStringVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}


### PR DESCRIPTION
This PR builds the necessary foundations for transitioning the state management system from SQLite to the subgraph. This PR doesn't alter the state of the oracle, it simply queries for relevant information from the subgraph and prints them out after every iteration in the main loop. We're using `graphql_client`.