### PR TITLE
Refer to subgraph by name, not ID

### DIFF
--- a/.local/.overmind.env
+++ b/.local/.overmind.env
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 OVERMIND_CAN_DIE=deploy-contract,deploy-subgraph
 
-export DEPLOYMENT_HASH=QmbtSBPVexNQhDcwrFbeUZCJrSZmRwT8JQaByvKNA3fR9S
+export DEPLOYMENT_NAME=edgeandnode/block-oracle
 
 export HARDHAT_JRPC_PORT=8545
 export IPFS_PORT=5001

--- a/.local/prelude.sh
+++ b/.local/prelude.sh
@@ -72,7 +72,7 @@ await_contract() {
 }
 
 subgraph_is_ready() {
-	curl --silent --fail "http://localhost:${GRAPH_NODE_GRAPHQL_PORT}/subgraphs/id/${DEPLOYMENT_HASH}" \
+	curl --silent --fail "http://localhost:${GRAPH_NODE_GRAPHQL_PORT}/subgraphs/name/${DEPLOYMENT_NAME}" \
 		-X POST \
 		-d '{"query": ""}' \
 		-H 'Content-Type: application/json; charset=utf-8' \


### PR DESCRIPTION
Changes the URL of the subgraph in `.overmind.env` by name, not hash, so we don't have to update it every time the code changes.