### PR TITLE
Don't use `cargo run`

### DIFF
--- a/.local/block-oracle.sh
+++ b/.local/block-oracle.sh
@@ -3,15 +3,15 @@ set -eu
 
 . ./prelude.sh
 
-cd ../crates/oracle/
+cd ../
 
 cargo build
 
 await_contract
 await_subgraph
 
-cargo run -- \
-	--config-file=config/dev/config.toml \
+./target/debug/block-oracle \
+	--config-file=./crates/oracle/config/dev/config.toml \
 	--database-url=:memory: \
 	--subgraph-url="http://127.0.0.1:${GRAPH_NODE_GRAPHQL_PORT}/subgraphs/name/edgeandnode/block-oracle" \
 	--owner-private-key=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d

--- a/.local/graph-node.sh
+++ b/.local/graph-node.sh
@@ -23,4 +23,4 @@ export IPFS="localhost:${IPFS_PORT}"
 export GRAPH_IPFS_TIMEOUT=10
 export GRAPH_LOG=debug
 
-cargo run -p graph-node
+./target/debug/graph-node


### PR DESCRIPTION

For some reason, calling `cargo run` after `cargo build` seems to trigger compilation again.