### PR TITLE
Make JSON-RPC exponential backoff logic more generic

### DIFF
--- a/crates/oracle/src/indexed_chain.rs
+++ b/crates/oracle/src/indexed_chain.rs
@@ -1,4 +1,4 @@
-use crate::{store::Caip2ChainId, transport::JsonRpcExponentialBackoff};
+use crate::{jsonrpc_utils::JsonRpcExponentialBackoff, store::Caip2ChainId};
 use epoch_encoding::BlockPtr;
 use std::time::Duration;
 use tracing::error;
@@ -13,7 +13,7 @@ pub struct IndexedChain {
 
 impl IndexedChain {
     pub fn new(chain_id: Caip2ChainId, jrpc_url: Url, retry_wait_time: Duration) -> Self {
-        let web3 = Web3::new(JsonRpcExponentialBackoff::new(jrpc_url, retry_wait_time));
+        let web3 = Web3::new(JsonRpcExponentialBackoff::http(jrpc_url, retry_wait_time));
         Self { chain_id, web3 }
     }
 

--- a/crates/oracle/src/jsonrpc_utils.rs
+++ b/crates/oracle/src/jsonrpc_utils.rs
@@ -9,25 +9,38 @@ use tracing::trace;
 use url::Url;
 use web3::{transports::Http, RequestId};
 
+/// A wrapper around [`web3::Transport`] that retries JSON-RPC calls on failure.
 #[derive(Debug, Clone)]
-pub struct JsonRpcExponentialBackoff {
-    inner: Arc<Http>,
+pub struct JsonRpcExponentialBackoff<T = Http> {
+    inner: Arc<T>,
     strategy: ExponentialBackoff,
 }
 
-impl JsonRpcExponentialBackoff {
-    pub fn new(jrpc_url: Url, max_wait: Duration) -> Self {
+impl<T> JsonRpcExponentialBackoff<T> {
+    pub fn new(transport: T, max_wait: Duration) -> Self {
         let strategy = ExponentialBackoffBuilder::new()
             .with_max_elapsed_time(Some(max_wait))
             .build();
-        // Unwrap: URLs were already parsed and are valid.
-        let client = Http::new(jrpc_url.as_str()).expect("failed to create HTTP transport");
-        let inner = Arc::new(client);
-        Self { inner, strategy }
+
+        Self {
+            inner: Arc::new(transport),
+            strategy,
+        }
     }
 }
 
-impl web3::Transport for JsonRpcExponentialBackoff {
+impl JsonRpcExponentialBackoff {
+    pub fn http(jrpc_url: Url, max_wait: Duration) -> Self {
+        // Unwrap: URLs were already parsed and are valid.
+        let client = Http::new(jrpc_url.as_str()).expect("failed to create HTTP transport");
+        Self::new(client, max_wait)
+    }
+}
+
+impl<T> web3::Transport for JsonRpcExponentialBackoff<T>
+where
+    T: web3::Transport + 'static,
+{
     type Out = Pin<Box<dyn Future<Output = web3::error::Result<Value>>>>;
 
     fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -6,12 +6,12 @@ mod encoder;
 mod epoch_tracker;
 mod event_source;
 mod indexed_chain;
+mod jsonrpc_utils;
 mod metrics;
 mod networks_diff;
 mod protocol_chain;
 mod store;
 mod subgraph;
-mod transport;
 
 use crate::ctrlc::CtrlcHandler;
 use diagnostics::init_logging;

--- a/crates/oracle/src/protocol_chain.rs
+++ b/crates/oracle/src/protocol_chain.rs
@@ -1,4 +1,4 @@
-use crate::{store::Caip2ChainId, transport::JsonRpcExponentialBackoff};
+use crate::{jsonrpc_utils::JsonRpcExponentialBackoff, store::Caip2ChainId};
 use futures::future::try_join_all;
 use secp256k1::SecretKey;
 use std::time::Duration;
@@ -27,7 +27,7 @@ impl ProtocolChain {
         transaction_confirmation_poll_interval_in_seconds: u64,
         transaction_confirmation_count: usize,
     ) -> Self {
-        let web3 = Web3::new(JsonRpcExponentialBackoff::new(jrpc_url, retry_wait_time));
+        let web3 = Web3::new(JsonRpcExponentialBackoff::http(jrpc_url, retry_wait_time));
         Self {
             chain_id,
             web3,


### PR DESCRIPTION
The exponential backoff logic is now generic over `web3::Transport`.