### PR TITLE
Let component errors dive the main loop

### DIFF
--- a/crates/oracle/src/epoch_tracker.rs
+++ b/crates/oracle/src/epoch_tracker.rs
@@ -1,11 +1,24 @@
 use crate::Config;
 use thiserror::Error;
-use tracing::debug;
+use tracing::{debug, error};
 
 #[derive(Debug, Error)]
 pub enum EpochTrackerError {
-    #[error("Failed to determine current epoch. No previous epoch was found in local storage.")]
+    #[error("Failed to determine current epoch")]
     PreviousEpochNotFound,
+}
+
+impl crate::MainLoopFlow for EpochTrackerError {
+    fn instruction(&self) -> crate::OracleControlFlow {
+        use std::ops::ControlFlow::*;
+        use EpochTrackerError::*;
+        match self {
+            error @ PreviousEpochNotFound => {
+                error!("{error}");
+                Continue(None)
+            }
+        }
+    }
 }
 
 /// Tracks current Ethereum mainnet epoch.

--- a/crates/oracle/src/error_handling.rs
+++ b/crates/oracle/src/error_handling.rs
@@ -1,0 +1,62 @@
+use std::{fmt::Display, ops::ControlFlow, time::Duration};
+
+pub type OracleControlFlow = ControlFlow<(), Option<Duration>>;
+
+/// Sends instructions to control the Oracle main loop flow.
+///
+/// When continuing, the implementor can opt to define a different duration for the sleep cycle.
+pub trait MainLoopFlow {
+    fn instruction(&self) -> OracleControlFlow;
+}
+
+pub fn handle_oracle_error(error: impl MainLoopFlow) -> OracleControlFlow {
+    error.instruction()
+}
+
+/// Helper function to convert a slice of items into a string, for use in [`Display`] contexts.
+pub fn format_slice(v: &[impl Display]) -> String {
+    if v.is_empty() {
+        return "[]".to_string();
+    }
+    let mut result = String::from("[");
+    let mut iterator = v.iter().peekable();
+    while let Some(value) = iterator.next() {
+        let text = value.to_string();
+        result.push_str(&text);
+        if iterator.peek().is_some() {
+            result.push_str(", ")
+        } else {
+            result.push(']');
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_slice_empty() {
+        let input: &[char] = &[];
+        let expected = "[]";
+        let result = format_slice(&input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn format_slice_single() {
+        let input = &['a'];
+        let expected = "[a]";
+        let result = format_slice(input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn format_slice_multiple() {
+        let input = "abcd".chars().collect::<Vec<_>>();
+        let expected = "[a, b, c, d]";
+        let result = format_slice(&input);
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
This introduces the `MainLoopFlow` trait that allows the main Oracle loop to be controlled by specific component errors.

This was implemented over the present "error enum tree", which might not be optimal for this idea.
So, we might want to refactor (or even erase) the `crate::Error` type in favor of generics.

Depends on #69.

*Please view this as an experiment on error handling design/organization for this project.*