### PR TITLE
fix: address warnings for eslint and solhint

### DIFF
--- a/packages/contracts/contracts/DataEdge.sol
+++ b/packages/contracts/contracts/DataEdge.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.12;
 ///        and decode the payload for different purposes.
 contract DataEdge {
     /// @dev Fallback function, accepts any payload
-    fallback() external {
+    fallback() external payable {
         // no-op
     }
 }

--- a/packages/contracts/contracts/EventfulDataEdge.sol
+++ b/packages/contracts/contracts/EventfulDataEdge.sol
@@ -10,7 +10,7 @@ contract EventfulDataEdge {
     event Log(bytes data);
 
     /// @dev Fallback function, accepts any payload
-    fallback() external {
+    fallback() external payable {
         emit Log(msg.data);
     }
 }

--- a/packages/contracts/test/dataedge.test.ts
+++ b/packages/contracts/test/dataedge.test.ts
@@ -13,7 +13,7 @@ describe('DataEdge', () => {
   let me: SignerWithAddress
 
   beforeEach(async () => {
-    ;[me] = await getSigners()
+    ;[me] = await getSigners() // eslint-disable-line @typescript-eslint/no-extra-semi
 
     const factory = (await getContractFactory('DataEdge', me)) as DataEdge__factory
     edge = await factory.deploy()

--- a/packages/contracts/test/eventful-dataedge.test.ts
+++ b/packages/contracts/test/eventful-dataedge.test.ts
@@ -13,7 +13,7 @@ describe('EventfulDataEdge', () => {
   let me: SignerWithAddress
 
   beforeEach(async () => {
-    ;[me] = await getSigners()
+    ;[me] = await getSigners() // eslint-disable-line @typescript-eslint/no-extra-semi
 
     const factory = (await getContractFactory('EventfulDataEdge', me)) as EventfulDataEdge__factory
     edge = await factory.deploy()


### PR DESCRIPTION
`eslint` had to be toggled off for lines with a semi-colon, as removing it caused `prettier-js` to raise errors.

`solhint` complained about the fallback function not being payable, so we turned it payable instead of suppressing that rule.

@abarmat, do you see making the fallback function payable as a problem? Otherwise, I can edit the `.solhint.json` file to ignore that rule.

Those lints are failing git pre-commit hooks, so fixing those will help us not having to disable commit checks for every commit :sweat: 