### PR TITLE
Remove `RefCell` from subgraph state

### DIFF
--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -15,8 +15,8 @@ pub type BigInt = u128;
 #[graphql(
     schema_path = "src/graphql/schema.graphql",
     query_path = "src/graphql/query.graphql",
-    response_derives = "Debug",
-    variables_derives = "Debug",
+    response_derives = "Debug,Clone",
+    variables_derives = "Debug,Clone",
     deprecated = "warn"
 )]
 pub struct SubgraphState;


### PR DESCRIPTION
This adds the Clone trait requirement to the generic state internal type.