### PR TITLE
Add a simple message encoder script

### DIFF
--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -6,7 +6,7 @@ use merkle::{merkle_root, MerkleLeaf};
 use messages::*;
 use std::collections::HashMap;
 
-pub use messages::{BlockPtr, CompressedMessage, Message};
+pub use messages::{BlockPtr, CompressedMessage, CompressedSetBlockNumbersForNextEpoch, Message};
 pub use serialize::serialize_messages;
 
 pub const CURRENT_ENCODING_VERSION: u64 = 0;

--- a/crates/oracle-encoder/Cargo.toml
+++ b/crates/oracle-encoder/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "oracle-encoder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "3", features = ["derive"] }
+epoch-encoding = { path = "../encoding" }
+hex = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/oracle-encoder/examples/samples.json
+++ b/crates/oracle-encoder/examples/samples.json
@@ -1,0 +1,32 @@
+[
+	{
+		"message": "Reset"
+	},
+	{
+		"message": "UpdateVersion",
+		"versionNumber": 420
+	},
+	{
+		"message": "RegisterNetworks",
+		"remove": [
+			0,
+			42
+		],
+		"add": [
+			"eip155:1"
+		]
+	},
+	{
+		"message": "SetBlockNumbersForNextEpoch",
+		"count": 100
+	},
+	{
+		"message": "SetBlockNumbersForNextEpoch",
+		"merkleRoot": "0xf3e001b1c3d4bc26fbe2e326cc651a8937942ed730663249f61e55ddc08f39e9",
+		"accelerations": [
+			1,
+			2,
+			3
+		]
+	}
+]

--- a/crates/oracle-encoder/src/main.rs
+++ b/crates/oracle-encoder/src/main.rs
@@ -1,0 +1,111 @@
+use clap::Parser;
+use epoch_encoding as ee;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{collections::HashMap, io};
+
+#[derive(Parser)]
+#[clap(name = "oracle-encoder")]
+#[clap(bin_name = "oracle-encoder")]
+#[clap(author, version, about, long_about = None)]
+struct OracleEncoder {
+    #[clap(long)]
+    json_path: String,
+}
+
+fn main() -> io::Result<()> {
+    let inputs = OracleEncoder::parse();
+
+    let file_contents = std::fs::read_to_string(inputs.json_path)?;
+    let messages: Vec<Message> = serde_json::from_str(&file_contents).unwrap();
+
+    let mut encoded_messages = vec![];
+    for m in messages {
+        let (message_type, ready_to_encode) = match m {
+            Message::Reset => ("Reset", ee::CompressedMessage::Reset),
+            Message::CorrectEpochs {} => (
+                "CorrectEpochs",
+                ee::CompressedMessage::CorrectEpochs {
+                    data_by_network_id: HashMap::new(),
+                },
+            ),
+            Message::UpdateVersion { version_number } => ("UpdateVersion", {
+                ee::CompressedMessage::UpdateVersion { version_number }
+            }),
+            Message::RegisterNetworks { remove, add } => ("RegisterNetworks", {
+                ee::CompressedMessage::RegisterNetworks { remove, add }
+            }),
+            Message::SetBlockNumbersForNextEpoch(SetBlockNumbersForNextEpoch::Empty { count }) => {
+                ("SetBlockNumbersForNextEpoch", {
+                    ee::CompressedMessage::SetBlockNumbersForNextEpoch(
+                        ee::CompressedSetBlockNumbersForNextEpoch::Empty { count },
+                    )
+                })
+            }
+            Message::SetBlockNumbersForNextEpoch(SetBlockNumbersForNextEpoch::NonEmpty {
+                merkle_root,
+                accelerations,
+            }) => (
+                "SetBlockNumbersForNextEpoch",
+                ee::CompressedMessage::SetBlockNumbersForNextEpoch(
+                    ee::CompressedSetBlockNumbersForNextEpoch::NonEmpty {
+                        root: merkle_root
+                            .try_into()
+                            .expect("Bad JSON: The Merkle root must have exactly 32 bytes."),
+                        accelerations,
+                    },
+                ),
+            ),
+        };
+        let mut payload = Vec::new();
+        ee::serialize_messages(&[ready_to_encode], &mut payload);
+        encoded_messages.push((message_type, payload));
+    }
+
+    for (i, (message_type, payload)) in encoded_messages.iter().enumerate() {
+        println!("{} ({}): 0x{}", i + 1, message_type, hex::encode(payload));
+    }
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "message")]
+#[serde(rename_all = "PascalCase")]
+pub enum Message {
+    SetBlockNumbersForNextEpoch(SetBlockNumbersForNextEpoch),
+    CorrectEpochs {
+        // TODO.
+    },
+    #[serde(rename_all = "camelCase")]
+    RegisterNetworks {
+        remove: Vec<u64>,
+        add: Vec<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    UpdateVersion {
+        version_number: u64,
+    },
+    Reset,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+#[serde(rename_all = "camelCase")]
+pub enum SetBlockNumbersForNextEpoch {
+    #[serde(rename_all = "camelCase")]
+    Empty { count: u64 },
+    #[serde(rename_all = "camelCase")]
+    NonEmpty {
+        #[serde(deserialize_with = "deserialize_hex")]
+        merkle_root: Vec<u8>,
+        accelerations: Vec<i64>,
+    },
+}
+
+fn deserialize_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    hex::decode(s.strip_prefix("0x").unwrap_or(s.as_str())).map_err(serde::de::Error::custom)
+}


### PR DESCRIPTION
```
# At the repo root
$ cargo build
$ ./target/debug/oracle-encoder --json-path crates/oracle-encoder/examples/samples.json
```

@juanmardefago  I'm also sending you the binary over slack so you can just run `oracle-encoder --json-path crates/oracle-encoder/examples/samples.json` without having to go through Cargo.