### PR TITLE
Oracle encoder example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ bin/
 # Subgraph
 generated/
 subgraph.yaml
+
+# oracle encoder json samples
+crates/oracle-encoder/examples/*.json
+!crates/oracle-encoder/examples/samples.json

--- a/crates/oracle-encoder/examples/01-empty-blocknums.jsonnet
+++ b/crates/oracle-encoder/examples/01-empty-blocknums.jsonnet
@@ -1,0 +1,8 @@
+// 1. Empty blocknums test with a particular count (SetBlocks(empty
+//    with N amount of empty epochs))
+
+local messages = import 'messages.libsonnet';
+
+[
+  messages.empty_block_numbers(100),
+]

--- a/crates/oracle-encoder/examples/02-register-networks-and-set-block-numbers-same-payload.jsonnet
+++ b/crates/oracle-encoder/examples/02-register-networks-and-set-block-numbers-same-payload.jsonnet
@@ -1,0 +1,12 @@
+// 2. Register(A) then SetBlocks(A) (same payload)
+
+// TODO: we must put the two messages inside the same payload, but we
+//       haven't implemented that int he oracle encoder yet. So, for
+//       now, this example is the same as 03.
+
+local messages = import 'messages.libsonnet';
+
+[
+  messages.add_networks(["A"]),
+  messages.set_block_numbers([15]),
+]

--- a/crates/oracle-encoder/examples/03-register-networks-and-set-block-numbers.jsonnet
+++ b/crates/oracle-encoder/examples/03-register-networks-and-set-block-numbers.jsonnet
@@ -1,0 +1,8 @@
+// 3. Register(A) then SetBlocks(A) (same payload)
+
+local messages = import 'messages.libsonnet';
+
+[
+  messages.add_networks(["A"]),
+  messages.set_block_numbers([15]),
+]

--- a/crates/oracle-encoder/examples/04-register-multiple-and-set-block-numbers-thrice.jsonnet
+++ b/crates/oracle-encoder/examples/04-register-multiple-and-set-block-numbers-thrice.jsonnet
@@ -1,0 +1,13 @@
+// 4. Register(A,B,C,D) then SetBlocks(A,B,C,D) x3 (same payload)
+
+// TODO: we must put those messages inside the same payload, but we
+//       haven't implemented that in the oracle-encoder yet.
+
+local messages = import 'messages.libsonnet';
+
+[
+  messages.add_networks(["A", "B", "C", "D"]),
+  messages.set_block_numbers([1,  2,  3,  4]),
+  messages.set_block_numbers([5,  6,  7,  8]),
+  messages.set_block_numbers([9, 10, 11, 12]),
+]

--- a/crates/oracle-encoder/examples/05-register-multiple-and-unregister.jsonnet
+++ b/crates/oracle-encoder/examples/05-register-multiple-and-unregister.jsonnet
@@ -1,0 +1,18 @@
+// 5. Register(A,B,C,D) then SetBlocks(A,B,C,D) (same payload), then
+//    Unregister(B) and SetBlocks(A,D,C) (both on a different payload
+//    than the original)
+
+// TODO: we must group those messages into two payloads, but we
+//       haven't implemented that in the oracle-encoder yet.
+
+local messages = import 'messages.libsonnet';
+
+[
+  // TODO: Payload #1 begins here
+  messages.add_networks(["A", "B", "C", "D"]),
+  messages.set_block_numbers([1,  2,  3,  4]),
+
+  // TODO: Payload #2 begins here
+  messages.remove_networks([1]),
+  messages.set_block_numbers([5, 6, 7]),
+]

--- a/crates/oracle-encoder/examples/Makefile
+++ b/crates/oracle-encoder/examples/Makefile
@@ -1,0 +1,28 @@
+all: 01-empty-blocknums.json \
+	02-register-networks-and-set-block-numbers-same-payload.json \
+	03-register-networks-and-set-block-numbers.json \
+	04-register-multiple-and-set-block-numbers-thrice.json \
+	05-register-multiple-and-unregister.json
+
+01-empty-blocknums.json:
+	jsonnet 01-empty-blocknums.jsonnet > $@
+
+02-register-networks-and-set-block-numbers-same-payload.json:
+	jsonnet 02-register-networks-and-set-block-numbers-same-payload.jsonnet > $@
+
+03-register-networks-and-set-block-numbers.json:
+	jsonnet 03-register-networks-and-set-block-numbers.jsonnet > $@
+
+04-register-multiple-and-set-block-numbers-thrice.json:
+	jsonnet 04-register-multiple-and-set-block-numbers-thrice.jsonnet > $@
+
+05-register-multiple-and-unregister.json:
+	jsonnet 05-register-multiple-and-unregister.jsonnet > $@
+
+.PHONY: clean
+clean:
+	rm -f 01-empty-blocknums.json
+	rm -f 02-register-networks-and-set-block-numbers-same-payload.json
+	rm -f 03-register-networks-and-set-block-numbers.json
+	rm -f 04-register-multiple-and-set-block-numbers-thrice.json
+	rm -f 05-register-multiple-and-unregister.json

--- a/crates/oracle-encoder/examples/messages.libsonnet
+++ b/crates/oracle-encoder/examples/messages.libsonnet
@@ -1,0 +1,28 @@
+// Functions for creating the JSON for each message type.
+
+local register_tag = "RegisterNetworks";
+local set_blocks_tag = "SetBlockNumbersForNextEpoch";
+local merkle_root = "0x66ebb0afd80c906e2b0564e921c3feefa9a5ecb71e98e3c7b7e661515e87dc49";
+
+{
+  register_networks(add, remove):: {
+    message: "RegisterNetworks",
+    add: add,
+    remove: remove,
+  },
+
+  add_networks(networks):: self.register_networks(networks,[]),
+
+  remove_networks(networks):: self.register_networks([], networks),
+
+  empty_block_numbers(count):: {
+    message: set_blocks_tag,
+    count: count,
+  },
+
+  set_block_numbers(accelerations):: {
+    message: set_blocks_tag,
+    merkleRoot: merkle_root,
+    accelerations: accelerations,
+  }
+}


### PR DESCRIPTION
This PR includes [`jsonnet`](https://jsonnet.org/learning/tutorial.html) files for generating `oracle-encoder` sample JSON data.

To compile the JSON files, just `cd` into `./crates/oracle-encoder/examples` and run `make`.