### PR TITLE
Slightly better error handling in `epoch_encoding`

### DIFF
--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -257,8 +257,11 @@ impl<'a> Oracle<'a> {
             "Compressing message(s)."
         );
 
-        let mut compression_engine = Encoder::new(CURRENT_ENCODING_VERSION, available_networks);
-        let encoded = compression_engine.encode(&messages[..]);
+        let mut compression_engine = Encoder::new(CURRENT_ENCODING_VERSION, available_networks)
+            .expect(format!("Can't prepare for encoding because something went wrong",).as_str());
+        let encoded = compression_engine
+            .encode(&messages[..])
+            .expect(format!("Encoding failed: {:?}", messages).as_str());
         debug!(encoded = ?encoded, "Successfully encoded message(s).");
 
         self.submit_oracle_messages(encoded).await?;


### PR DESCRIPTION
Some errors that arise during encoding are non-recoverable, but we still shouldn't crash. It's better to report an `Error`, bubble it up, and then crash from `main`. This is the better practice and allows us to have finer-grained control over panics and recovery.