### PR TITLE
Use DataEdge contract ABI instead of manually crafting transactions

### DIFF
--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -23,7 +23,6 @@ tokio = { version = "1", features = ["rt", "macros", "sync"] }
 toml = "0.5.8"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
-tiny-keccak = { version = "2", features = ["keccak"] }
 url = { version = "2.2.2", features = ["serde"] }
 web3 = { version = "0.18.0", features = ["signing"] }
 hex = "0.4.3"

--- a/crates/oracle/data-edge-abi.json
+++ b/crates/oracle/data-edge-abi.json
@@ -1,0 +1,19 @@
+[
+  {
+    "stateMutability": "nonpayable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "crossChainEpochOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -73,8 +73,6 @@ impl Config {
                 config_file.protocol_chain.name,
                 config_file.protocol_chain.jrpc,
                 retry_strategy_max_wait_time,
-                config_file.transaction_confirmation_poll_interval_in_seconds,
-                config_file.transaction_confirmation_count,
             )),
         }
     }

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -101,15 +101,15 @@ async fn main() -> Result<(), Error> {
 type SubgraphStateData = subgraph::subgraph_state::SubgraphStateGlobalState;
 
 /// The main application in-memory state
-struct Oracle<'a> {
-    emitter: Emitter<'a>,
+struct Oracle {
+    emitter: Emitter,
     epoch_tracker: EpochTracker,
     event_source: EventSource,
     subgraph_state: SubgraphStateTracker<SubgraphStateData, SubgraphQuery>,
 }
 
-impl<'a> Oracle<'a> {
-    pub fn new(config: &'a Config) -> Result<Self, Error> {
+impl Oracle {
+    pub fn new(config: &Config) -> Result<Self, Error> {
         let event_source = EventSource::new(config);
         let emitter = Emitter::new(config);
         let epoch_tracker = EpochTracker::new(config);


### PR DESCRIPTION
This removes a lot of (now) unnecessary code from both the Emitter and ProtocolChain components.

Fixes #104 