### PR TITLE
style: use hex strings instead of number arrays when logging bytes

### DIFF
--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hex = "0.4.3"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 
 [dev-dependencies]

--- a/crates/encoding/src/messages.rs
+++ b/crates/encoding/src/messages.rs
@@ -3,10 +3,19 @@ use std::collections::HashMap;
 pub type NetworkIndex = u64;
 pub type Bytes32 = [u8; 32];
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct BlockPtr {
     pub number: u64,
     pub hash: Bytes32,
+}
+
+impl std::fmt::Debug for BlockPtr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlockPtr")
+            .field("number", &self.number)
+            .field("hash", &format!("0x{}", hex::encode(&self.hash)))
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oracle/src/diagnostics.rs
+++ b/crates/oracle/src/diagnostics.rs
@@ -23,3 +23,7 @@ pub fn init_logging(log_level: LevelFilter) {
         .with(stdout)
         .init();
 }
+
+pub fn hex_string(bytes: &[u8]) -> String {
+    format!("0x{}", hex::encode(bytes))
+}

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -15,7 +15,7 @@ mod subgraph;
 mod subgraph_state;
 
 use crate::{ctrlc::CtrlcHandler, emitter::EmitterError};
-use diagnostics::init_logging;
+use diagnostics::{hex_string, init_logging};
 use ee::CURRENT_ENCODING_VERSION;
 use epoch_encoding::{self as ee, BlockPtr, Encoder, Message};
 use epoch_tracker::EpochTrackerError;
@@ -263,7 +263,10 @@ impl Oracle {
         let encoded = compression_engine
             .encode(&messages[..])
             .expect(format!("Encoding failed: {:?}", messages).as_str());
-        debug!(encoded = ?encoded, "Successfully encoded message(s).");
+        debug!(
+            encoded = %hex_string(&encoded),
+            "Successfully encoded message(s)."
+        );
 
         self.submit_oracle_messages(encoded).await?;
 


### PR DESCRIPTION
- `encoding` crate: Manual `fmt::Debug` impl. for `BlockPtr` that uses the `0x...` format for the block hash field.

- `oracle` crate: Added a helper `hex_string` function in the `diagnostics` module.


This PR is not exhaustive, so we might need to implement this standard for other log messages and types as we go.