### PR TITLE
fix: add 20% margin to gas price to prevent transaction failures

### DIFF
--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -53,9 +53,13 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
         )
         .await
         .map_err(TransactionMonitorError::Startup)?;
+
+        // Add 20% margin to the fetched gas price
+        let gas_price = gas_price + (gas_price / 5); // 20% increase
+
         debug!(
             %nonce,
-            %gas_price, "Fetched current nonce and gas price from provider"
+            %gas_price, "Fetched current nonce and gas price from provider (with 20% margin)"
         );
 
         let transaction_parameters = TransactionParameters {


### PR DESCRIPTION
## Summary
- Adds a 20% margin to the fetched gas price in the transaction monitor
- Prevents "max fee per gas less than block base fee" errors during gas price fluctuations

## Problem
The `correct-last-epoch` command was failing with gas price errors when the network's base fee increased between fetching the gas price and submitting the transaction. The transaction monitor was using the exact fetched gas price without any margin for fluctuations.

## Solution
Added a 20% margin to the fetched gas price (`gas_price + gas_price/5`) to provide headroom for gas price increases during transaction processing.

## Test plan
- [ ] Build the oracle with `cargo build --release`
- [ ] Run the `correct-last-epoch` command on a network with fluctuating gas prices
- [ ] Verify that transactions no longer fail with "max fee per gas less than block base fee" errors

🤖 Generated with [Claude Code](https://claude.ai/code)